### PR TITLE
adapter update

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -83,7 +83,7 @@ dependencies {
     implementation 'androidx.core:core-ktx:1.7.0'
     implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.5.0-rc01'
 
-    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.0'
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.1'
     implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.6.21'
 
     kapt 'androidx.room:room-compiler:2.4.2'

--- a/app/src/main/java/com/taitsmith/busboy/api/RemoteDataSource.kt
+++ b/app/src/main/java/com/taitsmith/busboy/api/RemoteDataSource.kt
@@ -1,9 +1,6 @@
 package com.taitsmith.busboy.api
 
 import com.taitsmith.busboy.di.ApiRepository
-import com.taitsmith.busboy.api.StopPredictionResponse.BustimeResponse.Prediction
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flow
 import javax.inject.Inject
 
 class RemoteDataSource @Inject constructor(apiRepository: ApiRepository) {

--- a/app/src/main/java/com/taitsmith/busboy/api/StopPredictionResponse.kt
+++ b/app/src/main/java/com/taitsmith/busboy/api/StopPredictionResponse.kt
@@ -2,6 +2,7 @@ package com.taitsmith.busboy.api
 
 import com.google.gson.annotations.SerializedName
 import com.google.gson.annotations.Expose
+import com.taitsmith.busboy.data.Prediction
 
 class StopPredictionResponse {
     @SerializedName("bustime-response")
@@ -21,39 +22,5 @@ class StopPredictionResponse {
         @SerializedName("prd")
         @Expose
         val prd: List<Prediction>? = null
-
-        class Prediction {
-            @SerializedName("stpnm")
-            @Expose
-            val stpnm: String? = null
-
-            @SerializedName("vid")
-            @Expose
-            val vid: String? = null
-
-            @SerializedName("rt")
-            @Expose
-            val rt: String? = null
-
-            @SerializedName("rtdir")
-            @Expose
-            val rtdir: String? = null
-
-            @SerializedName("des")
-            @Expose
-            val des: String? = null
-
-            @SerializedName("prdtm")
-            @Expose
-            val prdtm: String? = null
-
-            @SerializedName("dyn")
-            @Expose
-            val dyn: Int? = null
-
-            @SerializedName("prdctdn")
-            @Expose
-            var prdctdn: String? = null
-        }
     }
 }

--- a/app/src/main/java/com/taitsmith/busboy/data/Prediction.kt
+++ b/app/src/main/java/com/taitsmith/busboy/data/Prediction.kt
@@ -1,0 +1,39 @@
+package com.taitsmith.busboy.data
+
+import com.google.gson.annotations.Expose
+import com.google.gson.annotations.SerializedName
+import java.io.Serializable
+
+data class Prediction(
+    @SerializedName("stpnm")
+    @Expose
+    val stpnm: String? = null,
+
+    @SerializedName("vid")
+    @Expose
+    val vid: String? = null,
+
+    @SerializedName("rt")
+    @Expose
+    val rt: String? = null,
+
+    @SerializedName("rtdir")
+    @Expose
+    val rtdir: String? = null,
+
+    @SerializedName("des")
+    @Expose
+    val des: String? = null,
+
+    @SerializedName("prdtm")
+    @Expose
+    val prdtm: String? = null,
+
+    @SerializedName("dyn")
+    @Expose
+    val dyn: Int? = null,
+
+    @SerializedName("prdctdn")
+    @Expose
+    var prdctdn: String? = null
+): Serializable

--- a/app/src/main/java/com/taitsmith/busboy/data/Stop.kt
+++ b/app/src/main/java/com/taitsmith/busboy/data/Stop.kt
@@ -4,6 +4,7 @@ import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.PrimaryKey
 import com.google.gson.annotations.SerializedName
+import java.io.Serializable
 
 @Entity
 data class Stop(
@@ -23,4 +24,4 @@ data class Stop(
     var longitude: Double? = null,
 
     var linesServed: String? = null
-)
+): Serializable

--- a/app/src/main/java/com/taitsmith/busboy/data/StopDao.kt
+++ b/app/src/main/java/com/taitsmith/busboy/data/StopDao.kt
@@ -1,11 +1,12 @@
 package com.taitsmith.busboy.data
 
 import androidx.room.*
+import kotlinx.coroutines.flow.Flow
 
 @Dao
 interface StopDao {
     @Query("SELECT * FROM stop")
-    fun getAll(): List<Stop>
+    fun getAll(): Flow<List<Stop>>
 
     @Insert(onConflict =  OnConflictStrategy.REPLACE)
     fun insertAll(vararg stops: Stop)

--- a/app/src/main/java/com/taitsmith/busboy/ui/ByIdFragment.kt
+++ b/app/src/main/java/com/taitsmith/busboy/ui/ByIdFragment.kt
@@ -1,26 +1,22 @@
 package com.taitsmith.busboy.ui
 
-import android.content.Context
 import dagger.hilt.android.AndroidEntryPoint
 import com.taitsmith.busboy.viewmodels.ByIdViewModel
-import com.taitsmith.busboy.api.StopPredictionResponse.BustimeResponse
 import android.widget.EditText
 import com.taitsmith.busboy.utils.PredictionAdapter
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import android.os.Bundle
 import android.view.View
-import android.widget.AbsListView
-import android.widget.AdapterView
-import android.widget.ListView
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.navArgs
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
+import com.taitsmith.busboy.data.Prediction
 import com.taitsmith.busboy.databinding.ByIdFragmentBinding
-import com.taitsmith.busboy.utils.OnItemClickListener
-import com.taitsmith.busboy.utils.OnItemLongClickListener
+import com.taitsmith.busboy.ui.MainActivity.Companion.mainActivityViewModel
 import com.taitsmith.busboy.viewmodels.MainActivityViewModel
-import java.lang.ClassCastException
 import java.lang.IndexOutOfBoundsException
 
 @AndroidEntryPoint
@@ -30,16 +26,15 @@ class ByIdFragment : Fragment() {
     private val args: ByIdFragmentArgs by navArgs()
 
     private var _binding: ByIdFragmentBinding? = null
-    private var _predictionListView: ListView? = null
+    private var _predictionListView: RecyclerView? = null
 
     private val predictionListView get() = _predictionListView!!
     private val binding get() = _binding!!
-    private lateinit var listItemListener: OnItemClickListener
-    private lateinit var longClickListener: OnItemLongClickListener
+
     private lateinit var stopIdEditText: EditText
     private lateinit var predictionAdapter: PredictionAdapter
 
-    var predictionList: List<BustimeResponse.Prediction>? = null
+    var predictionList: List<Prediction>? = null
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
@@ -48,7 +43,7 @@ class ByIdFragment : Fragment() {
         _binding = ByIdFragmentBinding.inflate(inflater, container, false)
         _predictionListView = binding.predictionListView
         stopIdEditText = binding.stopEntryEditText
-        if (args.selectedNearbyStop != "none") byIdViewModel.getStopPredictions(args.selectedNearbyStop)
+//        if (args.selectedNearbyStop != "none") byIdViewModel.getStopPredictions(args.selectedNearbyStop)
         setListeners()
         return binding.root
     }
@@ -56,51 +51,32 @@ class ByIdFragment : Fragment() {
     private fun setListeners() {
         binding.searchByIdButton.setOnClickListener { search() }
         binding.addToFavoritesFab.setOnClickListener { byIdViewModel.addStopToFavorites() }
-        predictionListView.onItemClickListener =
-            AdapterView.OnItemClickListener { _: AdapterView<*>?, _: View?, i: Int, _: Long ->
-                listItemListener.onIdItemSelected(i)
-            }
-        predictionListView.onItemLongClickListener =
-            AdapterView.OnItemLongClickListener { _: AdapterView<*>?, _: View?, i: Int, _: Long ->
-                longClickListener.onIdLongClick(i)
-                true
-            }
-
-        predictionListView.setOnScrollListener(object: AbsListView.OnScrollListener {
-            override fun onScrollStateChanged(p0: AbsListView?, p1: Int) {}
-            //hide the fab when we get to the bottom of the list, unless the whole list is visible
-            override fun onScroll(p0: AbsListView?, p1: Int, p2: Int, p3: Int) {
-                if (p1 == (p3 - p2) && (p2 != p3)) binding.addToFavoritesFab.visibility = View.INVISIBLE
-                else binding.addToFavoritesFab.visibility = View.VISIBLE
-            }
-        })
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        predictionListView.layoutManager =
+            LinearLayoutManager(requireContext(), LinearLayoutManager.VERTICAL, false)
+        predictionAdapter = PredictionAdapter({
+            prediction ->
+            MainActivityViewModel.mutableStatusMessage.value = "LOADING"
+            MainActivity.prediction = prediction
+            mainActivityViewModel!!.getBusLocation(prediction.vid!!)
+        },{
+
+        })
+        predictionListView.adapter = predictionAdapter
+
         setObservers()
     }
 
-    override fun onAttach(context: Context) {
-        super.onAttach(context)
-        try {
-            listItemListener = context as OnItemClickListener
-            longClickListener = context as OnItemLongClickListener
-        } catch (e: ClassCastException) {
-            throw ClassCastException(
-                context.toString() +
-                        "Must Implement OnListItemSelectedListener"
-            )
-        }
-    }
 
     private fun setObservers() {
         byIdViewModel.mutableStopPredictions.observe(
             viewLifecycleOwner
-        ) { predictions: List<BustimeResponse.Prediction> ->
+        ) { predictions: List<Prediction> ->
             predictionList = predictions
-            predictionAdapter = PredictionAdapter(predictionList!!)
-            predictionListView.adapter = predictionAdapter
+            predictionAdapter.submitList(predictionList)
             binding.busFlagIV.visibility = View.INVISIBLE
             try {
                 val s = predictions[0].stpnm

--- a/app/src/main/java/com/taitsmith/busboy/ui/ByIdFragment.kt
+++ b/app/src/main/java/com/taitsmith/busboy/ui/ByIdFragment.kt
@@ -30,10 +30,12 @@ class ByIdFragment : Fragment() {
     private val args: ByIdFragmentArgs by navArgs()
 
     private var _binding: ByIdFragmentBinding? = null
+    private var _predictionListView: ListView? = null
+
+    private val predictionListView get() = _predictionListView!!
     private val binding get() = _binding!!
     private lateinit var listItemListener: OnItemClickListener
     private lateinit var longClickListener: OnItemLongClickListener
-    private lateinit var predictionListView: ListView
     private lateinit var stopIdEditText: EditText
     private lateinit var predictionAdapter: PredictionAdapter
 
@@ -44,7 +46,7 @@ class ByIdFragment : Fragment() {
         savedInstanceState: Bundle?
     ): View {
         _binding = ByIdFragmentBinding.inflate(inflater, container, false)
-        predictionListView = binding.predictionListView
+        _predictionListView = binding.predictionListView
         stopIdEditText = binding.stopEntryEditText
         if (args.selectedNearbyStop != "none") byIdViewModel.getStopPredictions(args.selectedNearbyStop)
         setListeners()
@@ -125,7 +127,9 @@ class ByIdFragment : Fragment() {
         super.onDestroyView()
         byIdViewModel.mutableStopPredictions.removeObservers(viewLifecycleOwner)
         predictionListView.adapter = null
+        binding.unbind()
         _binding = null
+        _predictionListView = null
     }
 }
 

--- a/app/src/main/java/com/taitsmith/busboy/ui/FavoritesFragment.kt
+++ b/app/src/main/java/com/taitsmith/busboy/ui/FavoritesFragment.kt
@@ -1,31 +1,22 @@
 package com.taitsmith.busboy.ui
 
-import android.content.Context
 import com.taitsmith.busboy.viewmodels.FavoritesViewModel
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import android.os.Bundle
-import android.util.Log
 import android.view.View
-import android.widget.AdapterView
-import android.widget.ListView
-import android.widget.Toast
 import androidx.fragment.app.Fragment
-import androidx.fragment.app.findFragment
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.coroutineScope
 import androidx.navigation.findNavController
+import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
-import com.taitsmith.busboy.data.Stop
 import com.taitsmith.busboy.databinding.FavoritesFragmentBinding
 import com.taitsmith.busboy.utils.NearbyAdapter
-import com.taitsmith.busboy.utils.OnItemClickListener
-import com.taitsmith.busboy.utils.OnItemLongClickListener
+import com.taitsmith.busboy.viewmodels.MainActivityViewModel
 import dagger.hilt.android.AndroidEntryPoint
-import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
-import java.lang.ClassCastException
 
 @AndroidEntryPoint
 class FavoritesFragment : Fragment() {
@@ -33,13 +24,9 @@ class FavoritesFragment : Fragment() {
     private val favoritesViewModel: FavoritesViewModel by viewModels()
     lateinit var favoritesListView: RecyclerView
 
-    private var _listItemListener: OnItemClickListener? = null
-    private var _listItemLongClickListener: OnItemLongClickListener? = null
     private var _binding: FavoritesFragmentBinding? = null
 
     private val binding get() = _binding!!
-    private val listItemListener get() = _listItemListener!!
-    private val listItemLongListener get() = _listItemLongClickListener!!
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
@@ -55,13 +42,15 @@ class FavoritesFragment : Fragment() {
         favoritesListView.layoutManager =
             LinearLayoutManager(requireContext(), LinearLayoutManager.VERTICAL, false)
         val adapter = NearbyAdapter ({
+            MainActivityViewModel.mutableStatusMessage.value = "LOADING"
             val action = FavoritesFragmentDirections
                 .actionFavoritesFragmentToByIdFragment(it.stopId!!)
             view.findNavController().navigate(action)
         }, {
             favoritesViewModel.deleteStop(it)
         })
-
+        val decoration = DividerItemDecoration(context, DividerItemDecoration.VERTICAL)
+        favoritesListView.addItemDecoration(decoration)
         favoritesListView.adapter = adapter
 
         lifecycle.coroutineScope.launch {
@@ -69,35 +58,11 @@ class FavoritesFragment : Fragment() {
                 adapter.submitList(it)
             }
         }
-        setObservers()
     }
-
-    private fun setObservers() {
-        FavoritesViewModel.stopToDelete.observe(viewLifecycleOwner) {
-            stop -> favoritesViewModel.deleteStop(stop)
-            favoritesViewModel.getFavoriteStops()
-        }
-    }
-
     override fun onDestroyView() {
         super.onDestroyView()
         _binding = null
-        _listItemListener = null
-        _listItemLongClickListener = null
         favoritesListView.adapter = null
-    }
-
-    override fun onAttach(context: Context) {
-        super.onAttach(context)
-        try {
-            _listItemListener = context as OnItemClickListener
-            _listItemLongClickListener = context as OnItemLongClickListener
-        } catch (e: ClassCastException) {
-            throw ClassCastException(
-                context.toString() +
-                        "Must Implement OnListItemSelectedListener"
-            )
-        }
     }
 
     companion object {

--- a/app/src/main/java/com/taitsmith/busboy/ui/FavoritesFragment.kt
+++ b/app/src/main/java/com/taitsmith/busboy/ui/FavoritesFragment.kt
@@ -5,24 +5,33 @@ import com.taitsmith.busboy.viewmodels.FavoritesViewModel
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import android.os.Bundle
+import android.util.Log
 import android.view.View
 import android.widget.AdapterView
 import android.widget.ListView
+import android.widget.Toast
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.findFragment
 import androidx.fragment.app.viewModels
+import androidx.lifecycle.coroutineScope
+import androidx.navigation.findNavController
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
+import com.taitsmith.busboy.data.Stop
 import com.taitsmith.busboy.databinding.FavoritesFragmentBinding
 import com.taitsmith.busboy.utils.NearbyAdapter
 import com.taitsmith.busboy.utils.OnItemClickListener
 import com.taitsmith.busboy.utils.OnItemLongClickListener
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.launch
 import java.lang.ClassCastException
 
 @AndroidEntryPoint
 class FavoritesFragment : Fragment() {
 
     private val favoritesViewModel: FavoritesViewModel by viewModels()
-    lateinit var favoritesListView: ListView
-    private lateinit var adapter: NearbyAdapter
+    lateinit var favoritesListView: RecyclerView
 
     private var _listItemListener: OnItemClickListener? = null
     private var _listItemLongClickListener: OnItemLongClickListener? = null
@@ -37,32 +46,33 @@ class FavoritesFragment : Fragment() {
         savedInstanceState: Bundle?
     ): View {
         _binding = FavoritesFragmentBinding.inflate(inflater, container, false)
-        favoritesListView = binding.favoritesListView
-        favoritesListView.onItemClickListener =
-            AdapterView.OnItemClickListener { _: AdapterView<*>?, _: View?, i: Int, _: Long ->
-                listItemListener.onFavoriteItemSelected(i)
-            }
-        favoritesListView.onItemLongClickListener =
-            AdapterView.OnItemLongClickListener { _, _, i, _ ->
-                listItemLongListener.onFavoriteLongClick(i)
-                true
-            }
         return binding.root
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        favoritesViewModel.getFavoriteStops()
+        favoritesListView = binding.favoritesListView
+        favoritesListView.layoutManager =
+            LinearLayoutManager(requireContext(), LinearLayoutManager.VERTICAL, false)
+        val adapter = NearbyAdapter ({
+            val action = FavoritesFragmentDirections
+                .actionFavoritesFragmentToByIdFragment(it.stopId!!)
+            view.findNavController().navigate(action)
+        }, {
+            favoritesViewModel.deleteStop(it)
+        })
+
+        favoritesListView.adapter = adapter
+
+        lifecycle.coroutineScope.launch {
+            favoritesViewModel.getFavoriteStops().collect {
+                adapter.submitList(it)
+            }
+        }
         setObservers()
     }
 
     private fun setObservers() {
-        favoritesViewModel.stopList.observe(viewLifecycleOwner) {
-            adapter = NearbyAdapter(it)
-            favoritesListView.adapter = adapter
-            FavoritesViewModel.favoriteStops.addAll(it)
-
-        }
         FavoritesViewModel.stopToDelete.observe(viewLifecycleOwner) {
             stop -> favoritesViewModel.deleteStop(stop)
             favoritesViewModel.getFavoriteStops()

--- a/app/src/main/java/com/taitsmith/busboy/ui/FavoritesFragment.kt
+++ b/app/src/main/java/com/taitsmith/busboy/ui/FavoritesFragment.kt
@@ -44,7 +44,7 @@ class FavoritesFragment : Fragment() {
         val adapter = NearbyAdapter ({
             MainActivityViewModel.mutableStatusMessage.value = "LOADING"
             val action = FavoritesFragmentDirections
-                .actionFavoritesFragmentToByIdFragment(it.stopId!!)
+                .actionFavoritesFragmentToByIdFragment(it)
             view.findNavController().navigate(action)
         }, {
             favoritesViewModel.deleteStop(it)

--- a/app/src/main/java/com/taitsmith/busboy/ui/MainActivity.kt
+++ b/app/src/main/java/com/taitsmith/busboy/ui/MainActivity.kt
@@ -20,12 +20,10 @@ import com.google.android.material.snackbar.Snackbar
 import com.taitsmith.busboy.R
 import com.taitsmith.busboy.api.StopPredictionResponse
 import com.taitsmith.busboy.data.Bus
-import com.taitsmith.busboy.data.Stop
 import com.taitsmith.busboy.databinding.ActivityMainBinding
 import com.taitsmith.busboy.utils.OnItemClickListener
 import com.taitsmith.busboy.utils.OnItemLongClickListener
 import com.taitsmith.busboy.viewmodels.ByIdViewModel
-import com.taitsmith.busboy.viewmodels.FavoritesViewModel
 import com.taitsmith.busboy.viewmodels.MainActivityViewModel
 import com.taitsmith.busboy.viewmodels.NearbyViewModel
 import dagger.hilt.android.AndroidEntryPoint
@@ -175,17 +173,6 @@ class MainActivity : AppCompatActivity(), OnItemClickListener, OnItemLongClickLi
             .show()
     }
 
-    private fun askToDeleteStop(stop: Stop) {
-        val builder = MaterialAlertDialogBuilder(this)
-        builder.setCancelable(false)
-        builder.setMessage(R.string.dialog_delete_stop)
-            .setPositiveButton(R.string.dialog_delete_stop_yes) { _: DialogInterface?, _: Int ->
-                FavoritesViewModel.stopToDelete.value = stop
-            }
-            .setNegativeButton(R.string.dialog_no_thanks, null)
-            .create()
-            .show()
-    }
     private fun showHelp() {
         val builder = MaterialAlertDialogBuilder(this)
         builder.setMessage(R.string.dialog_help)
@@ -213,44 +200,13 @@ class MainActivity : AppCompatActivity(), OnItemClickListener, OnItemLongClickLi
         }
     }
 
-    //the five following are for listviews on nearby, by id && favorites fragments
-    override fun onNearbyItemSelected(position: Int) {
-        val s = NearbyViewModel.stopList[position]!!.stopId
-        val action = NearbyFragmentDirections.actionNearbyFragmentToByIdFragment(s!!)
-        MainActivityViewModel.mutableStatusMessage.value = "LOADING"
-        ByIdViewModel.predictionList.clear()
-        navController.navigate(action)
-    }
-
     override fun onIdItemSelected(position: Int) {
         prediction = ByIdViewModel.predictionList[position]
         MainActivityViewModel.mutableStatusMessage.value = "LOADING"
         mainActivityViewModel!!.getBusLocation(prediction.vid!!)
     }
 
-    override fun onFavoriteItemSelected(position: Int) {
-        val s = FavoritesViewModel.favoriteStops[position].stopId
-        val action = FavoritesFragmentDirections.actionFavoritesFragmentToByIdFragment(s!!)
-        MainActivityViewModel.mutableStatusMessage.value = "LOADING"
-        ByIdViewModel.predictionList.clear()
-        navController.navigate(action)
-    }
-
-    override fun onNearbyLongClick(position: Int) {
-        MainActivityViewModel.mutableStatusMessage.value = "LOADING"
-        val (_, _, _, latitude, longitude) = NearbyViewModel.stopList[position]!!
-        val start =
-            NearbyViewModel.loc.latitude.toString() + "," + NearbyViewModel.loc.longitude.toString()
-        val end = (latitude!!).toString() + "," + (longitude!!).toString()
-        mainActivityViewModel!!.getDirectionsToStop(start, end)
-    }
-
     override fun onIdLongClick(position: Int) {}
-
-    override fun onFavoriteLongClick(position: Int) {
-        val stop = FavoritesViewModel.favoriteStops[position]
-        askToDeleteStop(stop)
-    }
 
     companion object {
         private const val PERMISSION_REQUEST_FINE_LOCATION = 6

--- a/app/src/main/java/com/taitsmith/busboy/ui/MainActivity.kt
+++ b/app/src/main/java/com/taitsmith/busboy/ui/MainActivity.kt
@@ -34,13 +34,14 @@ import im.delight.android.location.SimpleLocation
 @AndroidEntryPoint
 class MainActivity : AppCompatActivity(), OnItemClickListener, OnItemLongClickListener {
 
-    private lateinit var binding: ActivityMainBinding
     private lateinit var bottomNavigationView: BottomNavigationView
     private lateinit var navController: NavController
     private lateinit var navHostFragment: NavHostFragment
     lateinit var prediction: StopPredictionResponse.BustimeResponse.Prediction
 
     private var nearbyStatusUpdateTv: TextView? = null
+    private var _binding: ActivityMainBinding? = null
+    private val binding get() = _binding!!
 
     var nearbyFragment: NearbyFragment? = null
     var byIdFragment: ByIdFragment? = null
@@ -49,7 +50,7 @@ class MainActivity : AppCompatActivity(), OnItemClickListener, OnItemLongClickLi
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        binding = DataBindingUtil.setContentView(this, R.layout.activity_main)
+        _binding = DataBindingUtil.setContentView(this, R.layout.activity_main)
         acTransitApiKey = getString(R.string.ac_transit_key)
         mainActivityViewModel = ViewModelProvider(this)[MainActivityViewModel::class.java]
         bottomNavigationView = binding.mainTabLayout
@@ -152,7 +153,7 @@ class MainActivity : AppCompatActivity(), OnItemClickListener, OnItemLongClickLi
         MainActivityViewModel.mutableStatusMessage.removeObservers(this)
         MainActivityViewModel.mutableErrorMessage.removeObservers(this)
         mainActivityViewModel = null
-        binding.unbind()
+        _binding = null
     }
 
     private fun askToEnableLoc() {

--- a/app/src/main/java/com/taitsmith/busboy/ui/MainActivity.kt
+++ b/app/src/main/java/com/taitsmith/busboy/ui/MainActivity.kt
@@ -20,9 +20,8 @@ import com.google.android.material.snackbar.Snackbar
 import com.taitsmith.busboy.R
 import com.taitsmith.busboy.api.StopPredictionResponse
 import com.taitsmith.busboy.data.Bus
+import com.taitsmith.busboy.data.Prediction
 import com.taitsmith.busboy.databinding.ActivityMainBinding
-import com.taitsmith.busboy.utils.OnItemClickListener
-import com.taitsmith.busboy.utils.OnItemLongClickListener
 import com.taitsmith.busboy.viewmodels.ByIdViewModel
 import com.taitsmith.busboy.viewmodels.MainActivityViewModel
 import com.taitsmith.busboy.viewmodels.NearbyViewModel
@@ -30,14 +29,14 @@ import dagger.hilt.android.AndroidEntryPoint
 import im.delight.android.location.SimpleLocation
 
 @AndroidEntryPoint
-class MainActivity : AppCompatActivity(), OnItemClickListener, OnItemLongClickListener {
+class MainActivity : AppCompatActivity() {
 
     private lateinit var bottomNavigationView: BottomNavigationView
     private lateinit var navController: NavController
     private lateinit var navHostFragment: NavHostFragment
-    lateinit var prediction: StopPredictionResponse.BustimeResponse.Prediction
 
     private var nearbyStatusUpdateTv: TextView? = null
+
     private var _binding: ActivityMainBinding? = null
     private val binding get() = _binding!!
 
@@ -200,14 +199,6 @@ class MainActivity : AppCompatActivity(), OnItemClickListener, OnItemLongClickLi
         }
     }
 
-    override fun onIdItemSelected(position: Int) {
-        prediction = ByIdViewModel.predictionList[position]
-        MainActivityViewModel.mutableStatusMessage.value = "LOADING"
-        mainActivityViewModel!!.getBusLocation(prediction.vid!!)
-    }
-
-    override fun onIdLongClick(position: Int) {}
-
     companion object {
         private const val PERMISSION_REQUEST_FINE_LOCATION = 6
         var mainActivityViewModel: MainActivityViewModel? = null
@@ -215,5 +206,6 @@ class MainActivity : AppCompatActivity(), OnItemClickListener, OnItemLongClickLi
         var mutableBus: MutableLiveData<Bus> = MutableLiveData()
         var mutableNearbyStatusUpdater: MutableLiveData<String> = MutableLiveData()
         lateinit var acTransitApiKey: String
+        lateinit var prediction: Prediction
     }
 }

--- a/app/src/main/java/com/taitsmith/busboy/ui/NearbyFragment.kt
+++ b/app/src/main/java/com/taitsmith/busboy/ui/NearbyFragment.kt
@@ -64,7 +64,7 @@ class NearbyFragment : Fragment(), AdapterView.OnItemSelectedListener {
         adapter = NearbyAdapter ({ stop ->
             MainActivityViewModel.mutableStatusMessage.value = "LOADING"
             val action = NearbyFragmentDirections
-                .actionNearbyFragmentToByIdFragment(stop.stopId!!)
+                .actionNearbyFragmentToByIdFragment(stop)
             view.findNavController().navigate(action)
         }, {
             MainActivityViewModel.mutableStatusMessage.value = "LOADING"

--- a/app/src/main/java/com/taitsmith/busboy/ui/NearbyFragment.kt
+++ b/app/src/main/java/com/taitsmith/busboy/ui/NearbyFragment.kt
@@ -1,34 +1,25 @@
 package com.taitsmith.busboy.ui
 
-import android.content.Context
 import dagger.hilt.android.AndroidEntryPoint
 import com.taitsmith.busboy.utils.NearbyAdapter
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import android.os.Bundle
-import android.util.Log
 import android.view.View
 import android.widget.*
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
-import androidx.lifecycle.coroutineScope
 import androidx.navigation.findNavController
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.taitsmith.busboy.R
-import com.taitsmith.busboy.data.Stop
 import com.taitsmith.busboy.databinding.NearbyFragmentBinding
+import com.taitsmith.busboy.ui.MainActivity.Companion.mainActivityViewModel
 import com.taitsmith.busboy.viewmodels.NearbyViewModel
-import com.taitsmith.busboy.utils.OnItemClickListener
-import com.taitsmith.busboy.utils.OnItemLongClickListener
 import com.taitsmith.busboy.viewmodels.MainActivityViewModel
-import kotlinx.coroutines.launch
-import java.lang.ClassCastException
 
 @AndroidEntryPoint
 class NearbyFragment : Fragment(), AdapterView.OnItemSelectedListener {
-    private lateinit var listItemListener: OnItemClickListener
-    private lateinit var listItemLongListener: OnItemLongClickListener
     private lateinit var nearbyStopListView: RecyclerView
     private lateinit var nearbySearchButton: Button
     private lateinit var buslineSpinner: Spinner
@@ -71,29 +62,22 @@ class NearbyFragment : Fragment(), AdapterView.OnItemSelectedListener {
         nearbyStopListView.layoutManager = LinearLayoutManager(requireContext())
 
         adapter = NearbyAdapter ({ stop ->
-            val action = FavoritesFragmentDirections
-                .actionFavoritesFragmentToByIdFragment(stop.stopId!!)
+            MainActivityViewModel.mutableStatusMessage.value = "LOADING"
+            val action = NearbyFragmentDirections
+                .actionNearbyFragmentToByIdFragment(stop.stopId!!)
             view.findNavController().navigate(action)
         }, {
-            Log.d("LONG :" , it.name!!)
+            MainActivityViewModel.mutableStatusMessage.value = "LOADING"
+            val (_, _, _, latitude, longitude) = it
+            val start =
+                NearbyViewModel.loc.latitude.toString() + "," + NearbyViewModel.loc.longitude.toString()
+            val end = (latitude!!).toString() + "," + (longitude!!).toString()
+            mainActivityViewModel!!.getDirectionsToStop(start, end)
         })
 
         nearbyStopListView.adapter = adapter
 
         setObservers()
-    }
-
-    override fun onAttach(context: Context) {
-        super.onAttach(context)
-        try {
-            listItemListener = context as OnItemClickListener
-            listItemLongListener = context as OnItemLongClickListener
-        } catch (e: ClassCastException) {
-            throw ClassCastException(
-                context.toString() +
-                        "Must Implement OnListItemSelectedListener"
-            )
-        }
     }
 
     override fun onDestroyView() {
@@ -111,17 +95,6 @@ class NearbyFragment : Fragment(), AdapterView.OnItemSelectedListener {
     }
 
     private fun setListeners() {
-//        nearbyStopListView.onItemClickListener =
-//            AdapterView.OnItemClickListener { _: AdapterView<*>?, _: View?, i: Int, _: Long ->
-//                listItemListener.onNearbyItemSelected(i)
-//            }
-//
-//        nearbyStopListView.onItemLongClickListener =
-//            AdapterView.OnItemLongClickListener { _: AdapterView<*>?, _: View?, i: Int, _: Long ->
-//                listItemLongListener.onNearbyLongClick(i)
-//                true
-//            }
-
         nearbySearchButton.setOnClickListener {
             val s = nearbyEditText.text.toString()
             if (s.isNotEmpty()) {

--- a/app/src/main/java/com/taitsmith/busboy/utils/NearbyAdapter.kt
+++ b/app/src/main/java/com/taitsmith/busboy/utils/NearbyAdapter.kt
@@ -1,6 +1,5 @@
 package com.taitsmith.busboy.utils
 
-import android.util.Log
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.recyclerview.widget.DiffUtil

--- a/app/src/main/java/com/taitsmith/busboy/utils/NearbyAdapter.kt
+++ b/app/src/main/java/com/taitsmith/busboy/utils/NearbyAdapter.kt
@@ -1,55 +1,62 @@
 package com.taitsmith.busboy.utils
 
-import android.widget.BaseAdapter
-import android.view.ViewGroup
+import android.util.Log
 import android.view.LayoutInflater
-import android.view.View
+import android.view.ViewGroup
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.RecyclerView
+import androidx.recyclerview.widget.ListAdapter
 import com.taitsmith.busboy.data.Stop
 import com.taitsmith.busboy.databinding.ListItemNearbyBinding
 
-class NearbyAdapter(var stopList: List<Stop?>) : BaseAdapter() {
-    var binding: ListItemNearbyBinding? = null
-    override fun getCount(): Int {
-        return stopList.size
-    }
+class NearbyAdapter(
+    private val onItemClicked: (Stop) -> Unit,
+    private val onItemLongClick: (Stop) -> Unit
+): ListAdapter<Stop, NearbyAdapter.NearbyViewHolder>(DiffCallback) {
 
-    override fun getItem(i: Int): Any? {
-        return null
-    }
+    companion object {
+        private val DiffCallback = object: DiffUtil.ItemCallback<Stop>() {
+            override fun areItemsTheSame(oldItem: Stop, newItem: Stop): Boolean {
+                return oldItem.id == newItem.id
+            }
 
-    override fun getItemId(i: Int): Long {
-        return i.toLong()
-    }
-
-    override fun getItemViewType(position: Int): Int {
-        return position
-    }
-
-    override fun getViewTypeCount(): Int {
-        return if (stopList.isEmpty()) {
-            1
-        } else stopList.size
-    }
-
-    override fun getView(p0: Int, p1: View?, p2: ViewGroup?): View {
-        val holder: ViewHolder
-        val stop = stopList[p0]
-        if (p1 == null) {
-            binding = ListItemNearbyBinding.inflate(
-                LayoutInflater.from(p2!!.context),
-                p2, false
-            )
-            holder = ViewHolder(binding!!)
-            holder.view = binding!!.root
-            holder.view.tag = holder
-        } else {
-            holder = p1.tag as ViewHolder
+            override fun areContentsTheSame(oldItem: Stop, newItem: Stop): Boolean {
+                return oldItem == newItem
+            }
         }
-        binding!!.stop = stop
-        return holder.view
     }
 
-    private class ViewHolder(binding: ListItemNearbyBinding) {
-        var view: View = binding.root
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): NearbyViewHolder {
+        val viewHolder = NearbyViewHolder(
+            ListItemNearbyBinding.inflate(
+                LayoutInflater.from(parent.context),
+                parent,
+                false
+            )
+        )
+
+        viewHolder.itemView.setOnClickListener {
+            val position = viewHolder.bindingAdapterPosition
+            onItemClicked(getItem(position))
+        }
+
+        viewHolder.itemView.setOnLongClickListener {
+            val position = viewHolder.bindingAdapterPosition
+            onItemLongClick(getItem(position))
+            true
+        }
+        return viewHolder
+    }
+
+    override fun onBindViewHolder(holder: NearbyViewHolder, position: Int) {
+        holder.bind(getItem(position))
+    }
+
+    class NearbyViewHolder(
+        private var binding: ListItemNearbyBinding
+    ): RecyclerView.ViewHolder(binding.root) {
+        fun bind(stop: Stop) {
+            binding.stop = stop
+        }
     }
 }

--- a/app/src/main/java/com/taitsmith/busboy/utils/OnItemClickListener.kt
+++ b/app/src/main/java/com/taitsmith/busboy/utils/OnItemClickListener.kt
@@ -1,5 +1,0 @@
-package com.taitsmith.busboy.utils
-
-interface OnItemClickListener {
-    fun onIdItemSelected(position: Int)
-}

--- a/app/src/main/java/com/taitsmith/busboy/utils/OnItemClickListener.kt
+++ b/app/src/main/java/com/taitsmith/busboy/utils/OnItemClickListener.kt
@@ -1,7 +1,5 @@
 package com.taitsmith.busboy.utils
 
 interface OnItemClickListener {
-    fun onNearbyItemSelected(position: Int)
     fun onIdItemSelected(position: Int)
-    fun onFavoriteItemSelected(position: Int)
 }

--- a/app/src/main/java/com/taitsmith/busboy/utils/OnItemLongClickListener.kt
+++ b/app/src/main/java/com/taitsmith/busboy/utils/OnItemLongClickListener.kt
@@ -1,7 +1,5 @@
 package com.taitsmith.busboy.utils
 
 interface OnItemLongClickListener {
-    fun onNearbyLongClick(position: Int)
     fun onIdLongClick(position: Int)
-    fun onFavoriteLongClick(position: Int)
 }

--- a/app/src/main/java/com/taitsmith/busboy/utils/OnItemLongClickListener.kt
+++ b/app/src/main/java/com/taitsmith/busboy/utils/OnItemLongClickListener.kt
@@ -1,5 +1,0 @@
-package com.taitsmith.busboy.utils
-
-interface OnItemLongClickListener {
-    fun onIdLongClick(position: Int)
-}

--- a/app/src/main/java/com/taitsmith/busboy/utils/PredictionAdapter.kt
+++ b/app/src/main/java/com/taitsmith/busboy/utils/PredictionAdapter.kt
@@ -1,57 +1,62 @@
 package com.taitsmith.busboy.utils
 
-import android.widget.BaseAdapter
-import android.view.ViewGroup
 import android.view.LayoutInflater
-import android.view.View
-import com.taitsmith.busboy.api.StopPredictionResponse
+import android.view.ViewGroup
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+import com.taitsmith.busboy.data.Prediction
 import com.taitsmith.busboy.databinding.ListItemScheduleBinding
 
-class PredictionAdapter(var predictionList: List<StopPredictionResponse.BustimeResponse.Prediction>) :
-    BaseAdapter() {
-    var binding: ListItemScheduleBinding? = null
-    override fun getCount(): Int {
-        return predictionList.size
-    }
+class PredictionAdapter(
+    private val onItemClicked: (Prediction) -> Unit,
+    private val onItemLongClicked: (Prediction) -> Unit
+): ListAdapter<Prediction, PredictionAdapter.PredictionViewHolder>(DiffCallback) {
 
-    override fun getItem(i: Int): Any? {
-        return null
-    }
+    companion object {
+        private val DiffCallback = object: DiffUtil.ItemCallback<Prediction>() {
+            override fun areItemsTheSame(oldItem: Prediction, newItem: Prediction): Boolean {
+                return oldItem.stpnm == newItem.stpnm
+            }
 
-    override fun getItemId(i: Int): Long {
-        return i.toLong()
-    }
-
-    override fun getItemViewType(position: Int): Int {
-        return position
-    }
-
-    override fun getViewTypeCount(): Int {
-        return if (predictionList.isEmpty()) {
-            1
-        } else predictionList.size
-    }
-
-    override fun getView(p0: Int, p1: View?, p2: ViewGroup?): View {
-        val holder: ViewHolder
-        val p = predictionList[p0]
-        if (p1 == null) {
-            binding = ListItemScheduleBinding.inflate(
-                LayoutInflater.from(p2!!.context),
-                p2, false
-            )
-            holder = ViewHolder(binding!!)
-            holder.view = binding!!.root
-            holder.view.tag = holder
-        } else {
-            holder = p1.tag as ViewHolder
+            override fun areContentsTheSame(oldItem: Prediction, newItem: Prediction): Boolean {
+                return oldItem == newItem
+            }
         }
-        binding!!.prediction = p
-        return holder.view
     }
 
-    private class ViewHolder constructor(binding: ListItemScheduleBinding) {
-        var view: View = binding.root
+    override fun onCreateViewHolder( parent: ViewGroup, viewType: Int): PredictionViewHolder {
+        val viewHolder = PredictionViewHolder(
+            ListItemScheduleBinding.inflate(
+                LayoutInflater.from(parent.context),
+                parent,
+                false
+            )
+        )
 
+        viewHolder.itemView.setOnClickListener {
+            val position = viewHolder.bindingAdapterPosition
+            onItemClicked(getItem(position))
+        }
+
+        viewHolder.itemView.setOnLongClickListener {
+            val position = viewHolder.bindingAdapterPosition
+            onItemLongClicked(getItem(position))
+            true
+        }
+
+        return viewHolder
+    }
+
+    override fun onBindViewHolder(holder: PredictionViewHolder, position: Int) {
+        holder.bind(getItem(position))
+    }
+
+    class PredictionViewHolder(
+        private var binding: ListItemScheduleBinding
+    ): RecyclerView.ViewHolder(binding.root) {
+        fun bind(prediction: Prediction) {
+            binding.prediction = prediction
+        }
     }
 }

--- a/app/src/main/java/com/taitsmith/busboy/viewmodels/ByIdViewModel.kt
+++ b/app/src/main/java/com/taitsmith/busboy/viewmodels/ByIdViewModel.kt
@@ -8,7 +8,7 @@ import com.taitsmith.busboy.di.AcTransitApiInterface
 import com.taitsmith.busboy.di.DatabaseRepository
 import com.taitsmith.busboy.data.Stop
 import com.taitsmith.busboy.api.StopPredictionResponse
-import com.taitsmith.busboy.api.StopPredictionResponse.BustimeResponse.Prediction
+import com.taitsmith.busboy.data.Prediction
 import com.taitsmith.busboy.api.ApiInterface
 import com.taitsmith.busboy.di.ApiRepository
 import dagger.hilt.android.lifecycle.HiltViewModel

--- a/app/src/main/java/com/taitsmith/busboy/viewmodels/FavoritesViewModel.kt
+++ b/app/src/main/java/com/taitsmith/busboy/viewmodels/FavoritesViewModel.kt
@@ -2,17 +2,13 @@ package com.taitsmith.busboy.viewmodels
 
 import android.app.Application
 import androidx.lifecycle.AndroidViewModel
-import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.viewModelScope
-import com.taitsmith.busboy.api.StopDestinationResponse
 import com.taitsmith.busboy.data.Stop
 import com.taitsmith.busboy.di.DatabaseRepository
-import com.taitsmith.busboy.viewmodels.MainActivityViewModel.Companion.mutableErrorMessage
 import com.taitsmith.busboy.viewmodels.MainActivityViewModel.Companion.mutableStatusMessage
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -21,16 +17,10 @@ class FavoritesViewModel @Inject constructor(application: Application,
                                              private val databaseRepository: DatabaseRepository
                                             ): AndroidViewModel(application) {
 
-    private lateinit var favoriteLinesList: List<StopDestinationResponse.RouteDestination>
-    val stopList: MutableLiveData<List<Stop>> by lazy {
-        MutableLiveData<List<Stop>>()
-    }
-
     fun getFavoriteStops(): Flow<List<Stop>> = databaseRepository.getAllStops()
 
     companion object {
         lateinit var favoriteStops: MutableList<Stop>
-        lateinit var stopToDelete: MutableLiveData<Stop>
     }
 
     fun deleteStop(stop: Stop) {
@@ -42,6 +32,5 @@ class FavoritesViewModel @Inject constructor(application: Application,
 
     init {
         favoriteStops = ArrayList()
-        stopToDelete = MutableLiveData()
     }
 }

--- a/app/src/main/java/com/taitsmith/busboy/viewmodels/FavoritesViewModel.kt
+++ b/app/src/main/java/com/taitsmith/busboy/viewmodels/FavoritesViewModel.kt
@@ -11,6 +11,8 @@ import com.taitsmith.busboy.viewmodels.MainActivityViewModel.Companion.mutableEr
 import com.taitsmith.busboy.viewmodels.MainActivityViewModel.Companion.mutableStatusMessage
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -24,13 +26,7 @@ class FavoritesViewModel @Inject constructor(application: Application,
         MutableLiveData<List<Stop>>()
     }
 
-    fun getFavoriteStops() {
-        viewModelScope.launch(Dispatchers.IO) {
-            val stops = databaseRepository.getAllStops()
-            if (stops.isEmpty()) mutableErrorMessage.postValue("NO_FAVORITE_STOPS")
-            else stopList.postValue(stops)
-        }
-    }
+    fun getFavoriteStops(): Flow<List<Stop>> = databaseRepository.getAllStops()
 
     companion object {
         lateinit var favoriteStops: MutableList<Stop>

--- a/app/src/main/java/com/taitsmith/busboy/viewmodels/NearbyViewModel.kt
+++ b/app/src/main/java/com/taitsmith/busboy/viewmodels/NearbyViewModel.kt
@@ -77,13 +77,17 @@ class NearbyViewModel @Inject constructor(application: Application,
                     val response: Response<StopDestinationResponse?> = call!!.execute()
                     if (response.isSuccessful) {
                         val sb = StringBuilder()
-                        val destinations = response.body()?.routeDestinations!!
-                        destinations.forEach {
-                            sb.append(it.routeId)
-                                .append(" ")
-                                .append(it.destination)
-                                .append("\n")
-                            s.linesServed = sb.toString()
+                        if (response.body()!!.status == "No service today at this stop") {
+                            sb.append(response.body()!!.status) //sometimes this call returns a no service,
+                        } else {                                //even if there's service (happened today [memorial day])
+                            val destinations = response.body()?.routeDestinations!!
+                            destinations.forEach {
+                                sb.append(it.routeId)
+                                    .append(" ")
+                                    .append(it.destination)
+                                    .append("\n")
+                                s.linesServed = sb.toString()
+                            }
                         }
                     } else {
                         mutableErrorMessage.postValue("404")

--- a/app/src/main/res/layout/by_id_fragment.xml
+++ b/app/src/main/res/layout/by_id_fragment.xml
@@ -59,9 +59,9 @@
             app:srcCompat="@drawable/ic_busflag"
             tools:ignore="ImageContrastCheck" />
 
-        <ListView
+        <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/predictionListView"
-            android:layout_width="0dp"
+            android:layout_width="match_parent"
             android:layout_height="0dp"
             android:layout_marginStart="8dp"
             android:layout_marginTop="8dp"

--- a/app/src/main/res/layout/favorites_fragment.xml
+++ b/app/src/main/res/layout/favorites_fragment.xml
@@ -14,7 +14,7 @@
         android:layout_height="match_parent"
         tools:context=".ui.FavoritesFragment">
 
-        <ListView
+        <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/favoritesListView"
             android:layout_width="match_parent"
             android:layout_height="match_parent"

--- a/app/src/main/res/layout/list_item_nearby.xml
+++ b/app/src/main/res/layout/list_item_nearby.xml
@@ -15,7 +15,7 @@
     <androidx.cardview.widget.CardView
         android:id="@+id/nearbyListCardView"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
+        android:layout_height="wrap_content"
         app:cardElevation="4dp"
         app:cardCornerRadius="4dp">
 

--- a/app/src/main/res/layout/list_item_schedule.xml
+++ b/app/src/main/res/layout/list_item_schedule.xml
@@ -9,12 +9,12 @@
             type="com.taitsmith.busboy.utils.PredictionAdapter" />
         <variable
             name="prediction"
-            type="com.taitsmith.busboy.api.StopPredictionResponse.BustimeResponse.Prediction" />
+            type="com.taitsmith.busboy.data.Prediction" />
     </data>
 <androidx.cardview.widget.CardView
     android:id="@+id/scheduleListCardView"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
+    android:layout_height="wrap_content"
     app:cardElevation="4dp"
     app:cardCornerRadius="4dp">
 

--- a/app/src/main/res/layout/nearby_fragment.xml
+++ b/app/src/main/res/layout/nearby_fragment.xml
@@ -55,7 +55,7 @@
             app:layout_constraintGuide_percent="0.25" />
 
 
-        <ListView
+        <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/nearbyListView"
             android:layout_width="match_parent"
             android:layout_height="0dp"

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -20,8 +20,7 @@
             app:destination="@id/mapsFragment" />
         <argument
             android:name="selectedNearbyStop"
-            app:argType="string"
-            android:defaultValue="none"/>
+            app:argType="com.taitsmith.busboy.data.Stop" />
     </fragment>
     <fragment
         android:id="@+id/favoritesFragment"
@@ -39,11 +38,11 @@
         android:name="com.taitsmith.busboy.ui.NearbyFragment"
         android:label="NearbyFragment" >
         <action
-            android:id="@+id/action_nearbyFragment_to_byIdFragment"
-            app:destination="@id/byIdFragment" />
-        <action
             android:id="@+id/action_nearbyFragment_to_mapsFragment"
             app:destination="@id/mapsFragment" />
+        <action
+            android:id="@+id/action_nearbyFragment_to_byIdFragment"
+            app:destination="@id/byIdFragment" />
     </fragment>
     <fragment
         android:id="@+id/mapsFragment"


### PR DESCRIPTION
changes nearby and prediction adapter to extend listadapter instead of baseadapter. removes (now) unused click interfaces. changes room query to return flows. cleans up unnecessary leftover code + imports.