### PR TITLE
fix issue with observers retriggering on fragment change

### DIFF
--- a/app/src/main/java/com/taitsmith/busboy/ui/ByIdFragment.kt
+++ b/app/src/main/java/com/taitsmith/busboy/ui/ByIdFragment.kt
@@ -68,13 +68,13 @@ class ByIdFragment : Fragment() {
             LinearLayoutManager(requireContext(), LinearLayoutManager.VERTICAL, false)
         predictionAdapter = PredictionAdapter({
             prediction ->
+            byIdViewModel.setIsUpdated(true)
             MainActivityViewModel.mutableStatusMessage.value = "LOADING"
             MainActivity.prediction = prediction
             byIdViewModel.getBusLocation(prediction.vid!!)
-            byIdViewModel.setIsUpdated(true)
         },{
-            byIdViewModel.getBusDetails(it.vid!!)
             byIdViewModel.setIsUpdated(true)
+            byIdViewModel.getBusDetails(it.vid!!)
         })
         predictionListView.adapter = predictionAdapter
     }
@@ -111,8 +111,11 @@ class ByIdFragment : Fragment() {
         }
 
         byIdViewModel.busRouteWaypoints.observe(viewLifecycleOwner) {
-            val action = ByIdFragmentDirections.actionByIdFragmentToMapsFragment("route")
-            findNavController().navigate(action)
+            if (byIdViewModel.isUpdated.value == true) {
+                val action = ByIdFragmentDirections.actionByIdFragmentToMapsFragment("route")
+                findNavController().navigate(action)
+                byIdViewModel.setIsUpdated(false)
+            }
         }
     }
 

--- a/app/src/main/java/com/taitsmith/busboy/ui/NearbyFragment.kt
+++ b/app/src/main/java/com/taitsmith/busboy/ui/NearbyFragment.kt
@@ -56,6 +56,7 @@ class NearbyFragment : Fragment(), AdapterView.OnItemSelectedListener {
         fusedLocationClient = LocationServices.getFusedLocationProviderClient(requireActivity())
 
         setListeners()
+        setObservers()
 
         return binding.root
     }
@@ -72,6 +73,7 @@ class NearbyFragment : Fragment(), AdapterView.OnItemSelectedListener {
                 .actionNearbyFragmentToByIdFragment(stop)
             view.findNavController().navigate(action)
         }, {
+            nearbyViewModel.setIsUpdated(true)
             MainActivityViewModel.mutableStatusMessage.value = "LOADING"
             val (_, _, _, latitude, longitude) = it
             val start =
@@ -81,8 +83,6 @@ class NearbyFragment : Fragment(), AdapterView.OnItemSelectedListener {
         })
 
         nearbyStopListView.adapter = adapter
-
-        setObservers()
     }
 
     override fun onDestroyView() {
@@ -99,8 +99,12 @@ class NearbyFragment : Fragment(), AdapterView.OnItemSelectedListener {
         }
 
         nearbyViewModel.directionPolylineCoords.observe(viewLifecycleOwner) {
-            val action = NearbyFragmentDirections.actionNearbyFragmentToMapsFragment("directions")
-            findNavController().navigate(action)
+            if (nearbyViewModel.isUpdated.value == true) {
+                val action =
+                    NearbyFragmentDirections.actionNearbyFragmentToMapsFragment("directions")
+                findNavController().navigate(action)
+                nearbyViewModel.setIsUpdated(false)
+            }
         }
     }
 
@@ -119,8 +123,6 @@ class NearbyFragment : Fragment(), AdapterView.OnItemSelectedListener {
                     }
                 }
                 nearbyViewModel.getNearbyStops()
-            } else {
-                MainActivityViewModel.mutableErrorMessage.value = "NO_LOC_ENABLED"
             }
         }
     }

--- a/app/src/main/java/com/taitsmith/busboy/viewmodels/ByIdViewModel.kt
+++ b/app/src/main/java/com/taitsmith/busboy/viewmodels/ByIdViewModel.kt
@@ -70,7 +70,6 @@ class ByIdViewModel @Inject constructor(
         viewModelScope.launch(Dispatchers.IO){
             kotlin.runCatching {
                 _bus.postValue(apiRepository.getBusLocation(vehicleId))
-                _isUpdated.postValue(false)
             }.onFailure {
                 when (it.message) {
                     "null_coords" -> MainActivityViewModel.mutableErrorMessage
@@ -97,7 +96,6 @@ class ByIdViewModel @Inject constructor(
             kotlin.runCatching {
                 _busRouteWaypoints.postValue(apiRepository.getBusRouteWaypoints(routeName))
                 _isUpdated.postValue(false)
-
             }.onFailure {
                 it.printStackTrace()
                 when (it.message) {

--- a/app/src/main/java/com/taitsmith/busboy/viewmodels/NearbyViewModel.kt
+++ b/app/src/main/java/com/taitsmith/busboy/viewmodels/NearbyViewModel.kt
@@ -26,11 +26,11 @@ class NearbyViewModel @Inject constructor(application: Application,
 
     private val mapsKey: String = application.getString(R.string.google_directions_key)
 
+    private val _isUpdated = MutableLiveData<Boolean>()
+    val isUpdated: LiveData<Boolean> = _isUpdated
+
     private val _nearbyStops = MutableLiveData<List<Stop>>()
     val nearbyStops: LiveData<List<Stop>> = _nearbyStops
-
-    private val _locationEnabled = MutableLiveData<Boolean>()
-    var locationEnabled: LiveData<Boolean> = _locationEnabled
 
     //for getting lat/lon coordinates to draw walking directions on a map
     private val _directionPolylineCoords = MutableLiveData<List<LatLng>>()
@@ -65,7 +65,6 @@ class NearbyViewModel @Inject constructor(application: Application,
     fun checkLocationPerm(): Boolean {
         if (!loc.hasLocationEnabled()) {
             mutableErrorMessage.value = "NO_LOC_ENABLED" //granted permissions, but location is disabled.
-            _locationEnabled.value = false
             return false
         } else {
             if (ContextCompat.checkSelfPermission(
@@ -73,9 +72,7 @@ class NearbyViewModel @Inject constructor(application: Application,
                     Manifest.permission.ACCESS_FINE_LOCATION
                 ) == PackageManager.PERMISSION_GRANTED
             ) {
-                locationPermGranted.value = true
                 loc.beginUpdates()
-                _locationEnabled.value = true
             } else {
                 mutableErrorMessage.value = "NO_PERMISSION"
                 return false
@@ -89,7 +86,12 @@ class NearbyViewModel @Inject constructor(application: Application,
     fun getDirectionsToStop(start: String, stop: String) {
         viewModelScope.launch(Dispatchers.IO) {
             _directionPolylineCoords.postValue(apiRepository.getDirectionsToStop(start, stop, mapsKey))
+            _isUpdated.postValue(false)
         }
+    }
+
+    fun setIsUpdated(isUpdated: Boolean) {
+        _isUpdated.value = isUpdated
     }
 
     companion object {


### PR DESCRIPTION
adds 'updated' flags to prevent users getting stuck in a loop of fragment changes triggering livedata observers and showing the map screen