### PR TITLE
1.2.2 release

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -68,7 +68,7 @@ android {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
 
-    implementation platform('androidx.compose:compose-bom:2024.02.02')
+    implementation platform('androidx.compose:compose-bom:2024.03.00')
 
     //regular old java dependencies
     implementation 'androidx.appcompat:appcompat:1.6.1'
@@ -94,6 +94,7 @@ dependencies {
     implementation 'com.squareup.retrofit2:converter-gson:2.9.0'
 
     implementation 'com.github.delight-im:Android-SimpleLocation:v1.0.1'
+    implementation 'com.slack.eithernet:eithernet:1.8.1'
 
     //kotlin dependencies
     implementation 'androidx.core:core-ktx:1.12.0'

--- a/app/src/main/java/com/taitsmith/busboy/api/AcTransitRemoteDataSource.kt
+++ b/app/src/main/java/com/taitsmith/busboy/api/AcTransitRemoteDataSource.kt
@@ -26,7 +26,11 @@ class AcTransitRemoteDataSource @Inject constructor (@AcTransitApiInterface
         while (true) {
             when (val response = acTransitApiInterface.getStopPredictionList(stopId, rt)) {
                 is Success -> {
-                    if (!response.value.bustimeResponse.error.isNullOrEmpty()) throw Exception("NULL_PRED_RESPONSE")
+                    if (!response.value.bustimeResponse.error.isNullOrEmpty()) {
+                        if (response.value.bustimeResponse.error!![0].msg.equals("No service scheduled"))
+                            throw Exception("NO_SERVICE_SCHEDULED")
+                        else throw Exception("UNKNOWN")
+                    }
                     else emit(response.value.bustimeResponse.prd!!)
                     delay(refreshIntervalMillis)
                 }

--- a/app/src/main/java/com/taitsmith/busboy/api/AcTransitRemoteDataSource.kt
+++ b/app/src/main/java/com/taitsmith/busboy/api/AcTransitRemoteDataSource.kt
@@ -23,9 +23,9 @@ class AcTransitRemoteDataSource @Inject constructor (@AcTransitApiInterface
     //if you've got the app open on the by id screen we'll update it once per minute.
     private val refreshIntervalMillis: Long = 60000
 
-    val predictions: Flow<List<Prediction>> = flow {
+    fun predictions(s: String, r: String?): Flow<List<Prediction>> = flow {
         while (true) {
-            when (val response = acTransitApiInterface.getStopPredictionList(stopId, rt)) {
+            when (val response = acTransitApiInterface.getStopPredictionList(s, r)) {
                 is Success -> {
                     if (!response.value.bustimeResponse.error.isNullOrEmpty()) {
                         if (response.value.bustimeResponse.error!![0].msg.equals("No service scheduled"))
@@ -43,8 +43,8 @@ class AcTransitRemoteDataSource @Inject constructor (@AcTransitApiInterface
         }
     }
 
-    val serviceAlerts: Flow<ServiceAlertResponse> = flow {
-        when (val response = acTransitApiInterface.getServiceAlertsForStop(stopId)) {
+    fun serviceAlerts(stpid: String): Flow<ServiceAlertResponse> = flow {
+        when (val response = acTransitApiInterface.getServiceAlertsForStop(stpid)) {
             is Success -> emit(response.value)
             is Failure.ApiFailure -> throw Exception("404")
             is Failure.HttpFailure -> throw Exception("404")
@@ -53,16 +53,15 @@ class AcTransitRemoteDataSource @Inject constructor (@AcTransitApiInterface
         }
     }
 
-    val nearbyStops: Flow<List<Stop>> = flow {
-        when (val response = acTransitApiInterface.getNearbyStops(latLng.latitude,
+    fun nearbyStops(latLng: LatLng, distance: Int, route: String?): Flow<List<Stop>> = flow {
+        when (val response = acTransitApiInterface.getNearbyStops(
+            latLng.latitude,
             latLng.longitude,
-            1000,
+            distance,
             true,
-            rt)) {
-            is Success -> {
-                stopList = response.value
-                emit(response.value)
-            }
+            route
+        )) {
+            is Success -> emit(response.value)
             is Failure.ApiFailure -> throw Exception("404")
             is Failure.HttpFailure -> throw Exception("404")
             is Failure.NetworkFailure -> throw Exception("CALL_FAILURE")
@@ -70,36 +69,27 @@ class AcTransitRemoteDataSource @Inject constructor (@AcTransitApiInterface
         }
     }
 
-    val nearbyLinesServed: Flow<Stop> = flow {
-        stopList.forEach { stop ->
-            when (val destinations = acTransitApiInterface.getStopDestinations(stop.stopId)) {
+    fun linesServedByStop(stops: List<Stop>): Flow<StopDestinationResponse> = flow {
+        stops.forEach { stop ->
+            when (val response = acTransitApiInterface.getStopDestinations(stop.stopId)) {
                 is Success -> {
-                    val currentStop = destinations.value
-                    val sb = StringBuilder()
-                   currentStop.routeDestinations?.forEach {
-                        sb.append(it.routeId)
-                            .append(" ")
-                            .append(it.destination)
-                            .append("\n")
-                        stop.linesServed = sb.toString()
-                   }
+                    response.value.stopName = stop.name
+                    emit(response.value)
                 }
                 is Failure.ApiFailure -> throw Exception("404")
                 is Failure.HttpFailure -> throw Exception("404")
                 is Failure.NetworkFailure -> throw Exception("CALL_FAILURE")
                 is Failure.UnknownFailure -> throw Exception("UNKNOWN")
             }
-            emit(stop)
         }
     }
 
     //leave the map open to update the bus location every $refreshIntervalMillis
-    val vehicleLocation: Flow<Bus> = flow {
+    fun vehicleLocation(vid: String): Flow<Bus> = flow {
         while (true) {
-            when (val response = acTransitApiInterface.getVehicleInfo(vehicleId)) {
+            when (val response = acTransitApiInterface.getVehicleInfo(vid)) {
                 is Success -> {
-                    if (response.value.latitude == null) throw Exception("NULL_BUS_COORDS")
-                    else emit(response.value)
+                    emit(response.value)
                     delay(refreshIntervalMillis)
                 }
                 is Failure.ApiFailure -> throw Exception("404")
@@ -108,29 +98,5 @@ class AcTransitRemoteDataSource @Inject constructor (@AcTransitApiInterface
                 is Failure.UnknownFailure -> throw Exception("UNKNOWN")
             }
         }
-    }
-
-    companion object {
-        fun setStopInfo(s: String, r: String?) {
-            stopId = s
-            rt = r
-        }
-
-        fun setNearbyInfo(lat: Double, lng: Double, d: Int, r: String?) {
-            latLng = LatLng(lat, lng)
-            distance = d
-            rt = r
-        }
-
-        fun setVehicleId(vid: String) {
-            vehicleId = vid
-        }
-
-        private lateinit var stopId:    String
-        private lateinit var latLng:    LatLng
-        private lateinit var stopList:  List<Stop>
-        private var vehicleId =         "000"
-        private var distance: Int =     500
-        private var rt: String? =       null
     }
 }

--- a/app/src/main/java/com/taitsmith/busboy/api/ApiInterface.kt
+++ b/app/src/main/java/com/taitsmith/busboy/api/ApiInterface.kt
@@ -50,7 +50,7 @@ interface ApiInterface {
      suspend fun getVehicleInfo(
         @Path("vehicleId") vehicleId: String,
         @Query("token") token: String = BuildConfig.ac_transit_key
-    ): Bus
+    ): ApiResult<Bus, Unit>
 
     //get detailed info about a bus because you're a nerd and you like that stuff
      @GET("vehicle/{vehicleId}/characteristics")

--- a/app/src/main/java/com/taitsmith/busboy/api/ApiInterface.kt
+++ b/app/src/main/java/com/taitsmith/busboy/api/ApiInterface.kt
@@ -1,5 +1,7 @@
 package com.taitsmith.busboy.api
 
+import com.slack.eithernet.ApiResult
+import com.slack.eithernet.DecodeErrorBody
 import com.taitsmith.busboy.BuildConfig
 import com.taitsmith.busboy.data.*
 import com.taitsmith.busboy.ui.MainActivity
@@ -10,12 +12,13 @@ import retrofit2.http.Query
 interface ApiInterface {
 
     //returns predictions for given route at stop, otherwise all routes if rt == null
+    @DecodeErrorBody
     @GET("actrealtime/prediction/")
     suspend fun getStopPredictionList(
         @Query("stpid") stopId: String,
         @Query("rt") routeId: String?,
         @Query("token") token: String = BuildConfig.ac_transit_key
-    ): StopPredictionResponse
+    ): ApiResult<StopPredictionResponse, Unit>
 
     //find all active stops within {distance} feet of point
     @GET("stops/{latitude}/{longitude}/")

--- a/app/src/main/java/com/taitsmith/busboy/api/ApiInterface.kt
+++ b/app/src/main/java/com/taitsmith/busboy/api/ApiInterface.kt
@@ -64,7 +64,7 @@ interface ApiInterface {
      suspend fun getServiceAlertsForStop(
          @Query("stpid") stopId: String,
          @Query("token") token: String = BuildConfig.ac_transit_key
-     ): ServiceAlertResponse
+     ): ApiResult<ServiceAlertResponse, Unit>
 
     //talk to google and get walking directions from our location to the selected stop
     @GET("maps/api/directions/json")

--- a/app/src/main/java/com/taitsmith/busboy/api/ApiInterface.kt
+++ b/app/src/main/java/com/taitsmith/busboy/api/ApiInterface.kt
@@ -3,8 +3,8 @@ package com.taitsmith.busboy.api
 import com.slack.eithernet.ApiResult
 import com.slack.eithernet.DecodeErrorBody
 import com.taitsmith.busboy.BuildConfig
-import com.taitsmith.busboy.data.*
-import com.taitsmith.busboy.ui.MainActivity
+import com.taitsmith.busboy.data.Bus
+import com.taitsmith.busboy.data.Stop
 import retrofit2.http.GET
 import retrofit2.http.Path
 import retrofit2.http.Query
@@ -29,14 +29,14 @@ interface ApiInterface {
         @Query("active") active: Boolean,
         @Query("routeName") routeName: String?,
         @Query("token") token: String = BuildConfig.ac_transit_key
-    ): List<Stop>
+    ): ApiResult<List<Stop>, Unit>
 
     //get destinations for given stop so we can display NB/SB/EB/WB
     @GET("stop/{stopID}/destinations")
     suspend fun getStopDestinations(
         @Path("stopID") stopId: String?,
         @Query("token") token: String = BuildConfig.ac_transit_key
-    ): StopDestinationResponse
+    ): ApiResult<StopDestinationResponse, Unit>
 
     //get lat/lon waypoints so we can draw the route on a map
     @GET("route/{route}/waypoints")

--- a/app/src/main/java/com/taitsmith/busboy/api/ApiRepository.kt
+++ b/app/src/main/java/com/taitsmith/busboy/api/ApiRepository.kt
@@ -1,6 +1,5 @@
 package com.taitsmith.busboy.api
 
-import android.util.Log
 import com.google.android.gms.maps.model.LatLng
 import com.taitsmith.busboy.data.Bus
 import com.taitsmith.busboy.data.Prediction
@@ -12,10 +11,7 @@ import dagger.Module
 import dagger.hilt.InstallIn
 import dagger.hilt.android.components.ViewModelComponent
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.onEach
-import kotlinx.coroutines.runBlocking
 import javax.inject.Inject
 
 @Module
@@ -24,7 +20,7 @@ class ApiRepository @Inject constructor(@AcTransitApiInterface
                                         val acTransitApiInterface: ApiInterface,
                                         @MapsApiInterface
                                         val mapsApiInterface: ApiInterface,
-                                        remoteDataSource: RemoteDataSource
+                                        remoteDataSource: AcTransitRemoteDataSource
     ) {
 
     val stopPredictions: Flow<List<Prediction>> = remoteDataSource.predictions
@@ -35,6 +31,8 @@ class ApiRepository @Inject constructor(@AcTransitApiInterface
                 else it.prdctdn = "in " + it.prdctdn + " minutes"
             }
         }
+
+    val serviceAlerts: Flow<ServiceAlertResponse> = remoteDataSource.serviceAlerts
 
     suspend fun getBusLocation(vehicleId: String): Bus {
         val returnBus = acTransitApiInterface.getVehicleInfo(vehicleId)
@@ -79,10 +77,10 @@ class ApiRepository @Inject constructor(@AcTransitApiInterface
         return stopList
     }
 
-    //get service alerts for a given stop so we can inform users of delays, detours, stop closures etc
-    suspend fun getServiceAlertsForStop(stopId: String) : ServiceAlertResponse {
-       return acTransitApiInterface.getServiceAlertsForStop(stopId)
-    }
+//    //get service alerts for a given stop so we can inform users of delays, detours, stop closures etc
+//    suspend fun getServiceAlertsForStop(stopId: String) : ServiceAlertResponse {
+//       return acTransitApiInterface.getServiceAlertsForStop(stopId)
+//    }
 
     //get walking directions from current location to a bus stop. google returns a ton of information
     //and you have to dig through the list to get what we want: a collection of lat/lon points

--- a/app/src/main/java/com/taitsmith/busboy/api/ApiRepository.kt
+++ b/app/src/main/java/com/taitsmith/busboy/api/ApiRepository.kt
@@ -10,6 +10,7 @@ import dagger.Module
 import dagger.hilt.InstallIn
 import dagger.hilt.android.components.ViewModelComponent
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.map
 import javax.inject.Inject
 
@@ -54,6 +55,7 @@ class ApiRepository @Inject constructor(@AcTransitApiInterface
         }
 
     fun getLinesServedByStops(stops: List<Stop>): Flow<Stop> = remoteDataSource.linesServedByStop(stops)
+        .filter { !it.routeDestinations.isNullOrEmpty() }
         .map { response ->
             val sb = StringBuilder()
             response.routeDestinations?.forEach {

--- a/app/src/main/java/com/taitsmith/busboy/api/ApiRepository.kt
+++ b/app/src/main/java/com/taitsmith/busboy/api/ApiRepository.kt
@@ -37,12 +37,7 @@ class ApiRepository @Inject constructor(@AcTransitApiInterface
 
     val nearbyStopsWithLines: Flow<Stop> = remoteDataSource.nearbyLinesServed
 
-    suspend fun getBusLocation(vehicleId: String): Bus {
-        val returnBus = acTransitApiInterface.getVehicleInfo(vehicleId)
-        if (returnBus.latitude == null || returnBus.longitude == null) {
-            throw Exception("null_coords")
-        } else return acTransitApiInterface.getVehicleInfo(vehicleId)
-    }
+    val vehicleInfo: Flow<Bus> = remoteDataSource.vehicleLocation
 
     suspend fun getDetailedBusInfo(vid: String): Bus {
         return acTransitApiInterface.getDetailedVehicleInfo(vid)[0]

--- a/app/src/main/java/com/taitsmith/busboy/api/DirectionResponse.kt
+++ b/app/src/main/java/com/taitsmith/busboy/api/DirectionResponse.kt
@@ -1,7 +1,7 @@
 package com.taitsmith.busboy.api
 
-import com.google.gson.annotations.SerializedName
 import com.google.android.gms.maps.model.LatLng
+import com.google.gson.annotations.SerializedName
 
 class DirectionResponse {
     @SerializedName("geocoded_waypoints")

--- a/app/src/main/java/com/taitsmith/busboy/api/RemoteDataSource.kt
+++ b/app/src/main/java/com/taitsmith/busboy/api/RemoteDataSource.kt
@@ -1,0 +1,40 @@
+package com.taitsmith.busboy.api
+
+import com.taitsmith.busboy.data.Prediction
+import com.taitsmith.busboy.di.AcTransitApiInterface
+import com.taitsmith.busboy.di.MapsApiInterface
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.android.components.ViewModelComponent
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import javax.inject.Inject
+
+@Module
+@InstallIn(ViewModelComponent::class)
+class RemoteDataSource @Inject constructor (@AcTransitApiInterface
+                                            private val acTransitApiInterface: ApiInterface,
+                                            @MapsApiInterface
+                                            private val mapsApiInterface: ApiInterface
+) {
+    private val refreshIntervalMillis: Long = 60000
+
+    val predictions: Flow<List<Prediction>> = flow {
+        while (true) {
+            val response = acTransitApiInterface.getStopPredictionList(stopId, rt)
+            emit(response.bustimeResponse!!.prd!!)
+            delay(refreshIntervalMillis)
+        }
+    }
+
+    companion object {
+        fun setStopInfo(s: String, r: String?) {
+            stopId = s
+            rt = r
+        }
+
+        private lateinit var stopId: String
+        private var rt: String? = null
+    }
+}

--- a/app/src/main/java/com/taitsmith/busboy/api/ServiceAlertResponse.kt
+++ b/app/src/main/java/com/taitsmith/busboy/api/ServiceAlertResponse.kt
@@ -7,5 +7,5 @@ import java.io.Serializable
 data class ServiceAlertResponse(
     @SerializedName("bustime-response")
     @Expose
-    var bustimeResponse: BustimeResponse? = null
+    var bustimeResponse: BustimeResponse
 ) : Serializable

--- a/app/src/main/java/com/taitsmith/busboy/api/StopDestinationResponse.kt
+++ b/app/src/main/java/com/taitsmith/busboy/api/StopDestinationResponse.kt
@@ -21,6 +21,8 @@ class StopDestinationResponse {
     @SerializedName("RouteDestinations")
     var routeDestinations: List<RouteDestination>? = null
 
+    var stopName: String? = null
+
     @Entity
     data class RouteDestination (
 

--- a/app/src/main/java/com/taitsmith/busboy/api/StopPredictionResponse.kt
+++ b/app/src/main/java/com/taitsmith/busboy/api/StopPredictionResponse.kt
@@ -2,7 +2,6 @@ package com.taitsmith.busboy.api
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.taitsmith.busboy.data.Prediction
 
 data class StopPredictionResponse(
     @SerializedName("bustime-response")

--- a/app/src/main/java/com/taitsmith/busboy/api/StopPredictionResponse.kt
+++ b/app/src/main/java/com/taitsmith/busboy/api/StopPredictionResponse.kt
@@ -4,8 +4,8 @@ import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
 import com.taitsmith.busboy.data.Prediction
 
-class StopPredictionResponse {
+data class StopPredictionResponse(
     @SerializedName("bustime-response")
     @Expose
-    val bustimeResponse: BustimeResponse? = null
-}
+    val bustimeResponse: BustimeResponse
+)

--- a/app/src/main/java/com/taitsmith/busboy/api/WaypointResponse.kt
+++ b/app/src/main/java/com/taitsmith/busboy/api/WaypointResponse.kt
@@ -1,8 +1,8 @@
 package com.taitsmith.busboy.api
 
-import com.google.gson.annotations.SerializedName
-import com.google.gson.annotations.Expose
 import com.google.android.gms.maps.model.LatLng
+import com.google.gson.annotations.Expose
+import com.google.gson.annotations.SerializedName
 
 class WaypointResponse {
     @SerializedName("Patterns")

--- a/app/src/main/java/com/taitsmith/busboy/data/BusboyDatabase.kt
+++ b/app/src/main/java/com/taitsmith/busboy/data/BusboyDatabase.kt
@@ -2,19 +2,31 @@ package com.taitsmith.busboy.data
 
 import androidx.room.AutoMigration
 import androidx.room.Database
+import androidx.room.DeleteColumn
 import androidx.room.RoomDatabase
+import androidx.room.migration.AutoMigrationSpec
 import com.taitsmith.busboy.api.StopDestinationResponse
 
 @Database(
     entities = [Stop::class, StopDestinationResponse.RouteDestination::class],
-    version = 2,
+    exportSchema = true,
+    version = 3,
     autoMigrations = [
         AutoMigration (
             from = 1,
             to = 2
-        )]
+        ),
+        AutoMigration(
+            from = 2,
+            to = 3,
+            spec = BusboyDatabase.Migration_2_3::class
+        )
+    ]
 )
 abstract class BusboyDatabase : RoomDatabase() {
     abstract fun stopDao(): StopDao
     abstract fun routeDao(): RouteDestinationDao
+
+    @DeleteColumn(tableName = "Stop", columnName = "id")
+    class Migration_2_3 : AutoMigrationSpec
 }

--- a/app/src/main/java/com/taitsmith/busboy/data/RouteDestinationDao.kt
+++ b/app/src/main/java/com/taitsmith/busboy/data/RouteDestinationDao.kt
@@ -1,6 +1,11 @@
 package com.taitsmith.busboy.data
 
-import androidx.room.*
+import androidx.room.Dao
+import androidx.room.Delete
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import androidx.room.Update
 import com.taitsmith.busboy.api.StopDestinationResponse
 
 @Dao

--- a/app/src/main/java/com/taitsmith/busboy/data/Stop.kt
+++ b/app/src/main/java/com/taitsmith/busboy/data/Stop.kt
@@ -9,19 +9,19 @@ import java.io.Serializable
 @Entity
 data class Stop(
     @PrimaryKey(autoGenerate = false)
-    @ColumnInfo var id: Long? = null,
+    @ColumnInfo var id: Long,
 
     @SerializedName("StopId")
-    var stopId: String? = null,
+    var stopId: String,
 
     @SerializedName("Name")
-    var name: String? = null,
+    var name: String,
 
     @SerializedName("Latitude")
-    var latitude: Double? = null,
+    var latitude: Double,
 
     @SerializedName("Longitude")
-    var longitude: Double? = null,
+    var longitude: Double,
 
     var linesServed: String? = null
 ): Serializable

--- a/app/src/main/java/com/taitsmith/busboy/data/Stop.kt
+++ b/app/src/main/java/com/taitsmith/busboy/data/Stop.kt
@@ -9,19 +9,19 @@ import java.io.Serializable
 @Entity
 data class Stop(
     @PrimaryKey(autoGenerate = false)
-    @ColumnInfo var id: Long,
+    @ColumnInfo var id: Long? = null,
 
     @SerializedName("StopId")
-    var stopId: String,
+    var stopId: String? = null,
 
     @SerializedName("Name")
-    var name: String,
+    var name: String? = null,
 
     @SerializedName("Latitude")
-    var latitude: Double,
+    var latitude: Double? = null,
 
     @SerializedName("Longitude")
-    var longitude: Double,
+    var longitude: Double? = null,
 
     var linesServed: String? = null
 ): Serializable

--- a/app/src/main/java/com/taitsmith/busboy/data/Stop.kt
+++ b/app/src/main/java/com/taitsmith/busboy/data/Stop.kt
@@ -1,6 +1,5 @@
 package com.taitsmith.busboy.data
 
-import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.PrimaryKey
 import com.google.gson.annotations.SerializedName
@@ -8,11 +7,10 @@ import java.io.Serializable
 
 @Entity
 data class Stop(
-    @PrimaryKey(autoGenerate = false)
-    @ColumnInfo var id: Long? = null,
 
+    @PrimaryKey
     @SerializedName("StopId")
-    var stopId: String? = null,
+    var stopId: String = "",
 
     @SerializedName("Name")
     var name: String? = null,

--- a/app/src/main/java/com/taitsmith/busboy/data/StopDao.kt
+++ b/app/src/main/java/com/taitsmith/busboy/data/StopDao.kt
@@ -1,6 +1,11 @@
 package com.taitsmith.busboy.data
 
-import androidx.room.*
+import androidx.room.Dao
+import androidx.room.Delete
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import androidx.room.Update
 import kotlinx.coroutines.flow.Flow
 
 @Dao

--- a/app/src/main/java/com/taitsmith/busboy/di/ApiInterfaceModule.kt
+++ b/app/src/main/java/com/taitsmith/busboy/di/ApiInterfaceModule.kt
@@ -1,5 +1,7 @@
 package com.taitsmith.busboy.di
 
+import com.slack.eithernet.ApiResultCallAdapterFactory
+import com.slack.eithernet.ApiResultConverterFactory
 import com.taitsmith.busboy.api.ApiInterface
 import dagger.Module
 import dagger.Provides
@@ -34,7 +36,9 @@ object ApiInterfaceModule {
 
         val retrofit = Retrofit.Builder()
             .baseUrl("https://api.actransit.org/transit/")
+            .addConverterFactory(ApiResultConverterFactory)
             .addConverterFactory(GsonConverterFactory.create())
+            .addCallAdapterFactory(ApiResultCallAdapterFactory)
             .client(client)
             .build()
         return retrofit.create(ApiInterface::class.java)

--- a/app/src/main/java/com/taitsmith/busboy/di/DatabaseRepository.kt
+++ b/app/src/main/java/com/taitsmith/busboy/di/DatabaseRepository.kt
@@ -1,9 +1,9 @@
 package com.taitsmith.busboy.di
 
+import com.taitsmith.busboy.api.StopDestinationResponse.RouteDestination
 import com.taitsmith.busboy.data.RouteDestinationDao
 import com.taitsmith.busboy.data.Stop
 import com.taitsmith.busboy.data.StopDao
-import com.taitsmith.busboy.api.StopDestinationResponse.RouteDestination
 import javax.inject.Inject
 
 class DatabaseRepository @Inject constructor(

--- a/app/src/main/java/com/taitsmith/busboy/di/LocationRepository.kt
+++ b/app/src/main/java/com/taitsmith/busboy/di/LocationRepository.kt
@@ -7,6 +7,7 @@ import com.google.android.gms.location.FusedLocationProviderClient
 import com.google.android.gms.location.LocationCallback
 import com.google.android.gms.location.LocationRequest
 import com.google.android.gms.location.LocationResult
+import com.google.android.gms.location.Priority
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import javax.inject.Inject
@@ -28,10 +29,11 @@ class LocationRepository @Inject constructor(
     //this can't be called without permission so ignore lint
     @SuppressLint("MissingPermission")
     fun startUpdates() {
-        val request = LocationRequest.create().apply {
-            priority = LocationRequest.PRIORITY_LOW_POWER
-            interval = 300_000
-        }
+        val request = LocationRequest.Builder(
+            Priority.PRIORITY_LOW_POWER,
+            300_000
+        ).build()
+
         locationProviderClient.requestLocationUpdates(
             request,
             callback,

--- a/app/src/main/java/com/taitsmith/busboy/di/StatusRepository.kt
+++ b/app/src/main/java/com/taitsmith/busboy/di/StatusRepository.kt
@@ -8,7 +8,7 @@ import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
-class StatusRepo @Inject constructor(): StatusInterface {
+class StatusRepository @Inject constructor(): StatusInterface {
 
     var state: MutableStateFlow<LoadingState> = MutableStateFlow(LoadingState.Success)
 

--- a/app/src/main/java/com/taitsmith/busboy/di/StatusRepository.kt
+++ b/app/src/main/java/com/taitsmith/busboy/di/StatusRepository.kt
@@ -1,5 +1,6 @@
-package com.taitsmith.busboy.utils
+package com.taitsmith.busboy.di
 
+import com.taitsmith.busboy.utils.StatusInterface
 import com.taitsmith.busboy.viewmodels.MainActivityViewModel.LoadingState
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.update

--- a/app/src/main/java/com/taitsmith/busboy/ui/ByIdFragment.kt
+++ b/app/src/main/java/com/taitsmith/busboy/ui/ByIdFragment.kt
@@ -2,7 +2,6 @@ package com.taitsmith.busboy.ui
 
 import android.annotation.SuppressLint
 import android.os.Bundle
-import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -21,11 +20,11 @@ import com.taitsmith.busboy.data.Prediction
 import com.taitsmith.busboy.databinding.FragmentByIdBinding
 import com.taitsmith.busboy.utils.PredictionAdapter
 import com.taitsmith.busboy.viewmodels.ByIdViewModel
+import com.taitsmith.busboy.viewmodels.ByIdViewModel.PredictionState
 import com.taitsmith.busboy.viewmodels.MainActivityViewModel
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import com.taitsmith.busboy.viewmodels.ByIdViewModel.PredictionState
 
 @AndroidEntryPoint
 class ByIdFragment : Fragment() {
@@ -66,11 +65,8 @@ class ByIdFragment : Fragment() {
                 byIdViewModel.predictionFlow.collect {
                     when(it) {
                         is PredictionState.Success  -> setList(it.predictions)
-                        is PredictionState.Error    -> Log.d("ERROR", it.exception.message.toString())
-                        is PredictionState.Loading  -> {
-                            if (it.loading) MainActivityViewModel.mutableStatusMessage.value = "LOADING"
-                            else MainActivityViewModel.mutableStatusMessage.value = "LOADED"
-                        }
+                        is PredictionState.Error    -> MainActivityViewModel.mutableErrorMessage.value = it.exception.message
+                        is PredictionState.Loading  -> {}
                     }
                 }
             }
@@ -81,7 +77,6 @@ class ByIdFragment : Fragment() {
 
         return binding.root
     }
-
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
@@ -99,7 +94,6 @@ class ByIdFragment : Fragment() {
         })
         predictionListView.adapter = predictionAdapter
     }
-
 
     private fun setListeners() {
         binding.searchByIdButton.setOnClickListener { search() }
@@ -130,7 +124,7 @@ class ByIdFragment : Fragment() {
         }
 
         byIdViewModel.alerts.observe(viewLifecycleOwner) { alerts ->
-            val alertList = alerts.bustimeResponse?.sb
+            val alertList = alerts.bustimeResponse.sb
             if (!alertList.isNullOrEmpty() && byIdViewModel.alertShown.value == false) {
                 val snackbar = Snackbar.make(binding.root,
                     resources.getQuantityString(R.plurals.snackbar_service_alerts, alertList.size, alertList.size),

--- a/app/src/main/java/com/taitsmith/busboy/ui/ByIdFragment.kt
+++ b/app/src/main/java/com/taitsmith/busboy/ui/ByIdFragment.kt
@@ -114,6 +114,7 @@ class ByIdFragment : Fragment() {
                 val action = ByIdFragmentDirections.actionByIdFragmentToMapsFragment("route")
                 findNavController().navigate(action)
                 byIdViewModel.setIsUpdated(false)
+                byIdViewModel.updateStatus(false, null)
             }
         }
 

--- a/app/src/main/java/com/taitsmith/busboy/ui/ByIdFragment.kt
+++ b/app/src/main/java/com/taitsmith/busboy/ui/ByIdFragment.kt
@@ -68,11 +68,6 @@ class ByIdFragment : Fragment() {
             }
         }
 
-        /*  we want to determine if we're going to take this bus and display its location
-            on a map, or if we're going to take it and display detailed information about
-            it to the user. the bus object for map display has minimal information so we can
-            check if certain things are null/empty and determine where to go from there
-         */
         viewLifecycleOwner.lifecycleScope.launch {
             repeatOnLifecycle(Lifecycle.State.STARTED) {
                 byIdViewModel.bus.collect {
@@ -111,7 +106,7 @@ class ByIdFragment : Fragment() {
 
     private fun setListeners() {
         binding.searchByIdButton.setOnClickListener { search() }
-//        binding.addToFavoritesFab.setOnClickListener { byIdViewModel.addStopToFavorites() }
+        binding.addToFavoritesFab.setOnClickListener { byIdViewModel.addStopToFavorites() }
     }
 
     private fun setObservers() {

--- a/app/src/main/java/com/taitsmith/busboy/ui/ByIdFragment.kt
+++ b/app/src/main/java/com/taitsmith/busboy/ui/ByIdFragment.kt
@@ -58,7 +58,7 @@ class ByIdFragment : Fragment() {
 
         viewLifecycleOwner.lifecycleScope.launch {
             repeatOnLifecycle(Lifecycle.State.STARTED) {
-                byIdViewModel.predictionFlow.collect {
+                byIdViewModel.predictions.collect {
                     when(it) {
                         is PredictionState.Success  -> setList(it.predictions)
                         is PredictionState.Error    -> byIdViewModel.updateStatus(null, it.exception.message!!)
@@ -73,9 +73,9 @@ class ByIdFragment : Fragment() {
                 byIdViewModel.bus.collect {
                     when (it) {
                         is BusState.Error   -> {}
-                        is BusState.Initial -> byIdViewModel.getWaypoints(MainActivity.prediction.rt!!)
+                        is BusState.Initial -> byIdViewModel.getWaypoints()
                         is BusState.Updated -> {}
-                        is BusState.Detail  -> BusDetailFragment(it.bus).show(childFragmentManager, "deatils")
+                        is BusState.Detail  -> BusDetailFragment(it.bus).show(childFragmentManager, "details")
                         BusState.Loading    -> {}
                     }
                 }
@@ -94,12 +94,10 @@ class ByIdFragment : Fragment() {
             LinearLayoutManager(requireContext(), LinearLayoutManager.VERTICAL, false)
         predictionAdapter = PredictionAdapter({ prediction ->
             byIdViewModel.setIsUpdated(true)
-            MainActivity.prediction = prediction
-            byIdViewModel.getBusLocation(prediction.vid!!)
+            byIdViewModel.getBusLocation(prediction.vid!!, prediction.rt!!)
         },{
             byIdViewModel.setIsUpdated(true)
-            it.vid?.let { it1 -> byIdViewModel.getBusDetails(it1)
-            }
+            it.vid?.let { vid -> byIdViewModel.getBusDetails(vid) }
         })
         predictionListView.adapter = predictionAdapter
     }

--- a/app/src/main/java/com/taitsmith/busboy/ui/FavoritesFragment.kt
+++ b/app/src/main/java/com/taitsmith/busboy/ui/FavoritesFragment.kt
@@ -13,7 +13,6 @@ import androidx.recyclerview.widget.RecyclerView
 import com.taitsmith.busboy.databinding.FavoritesFragmentBinding
 import com.taitsmith.busboy.utils.NearbyAdapter
 import com.taitsmith.busboy.viewmodels.FavoritesViewModel
-import com.taitsmith.busboy.viewmodels.MainActivityViewModel
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
 
@@ -21,7 +20,7 @@ import kotlinx.coroutines.launch
 class FavoritesFragment : Fragment() {
 
     private val favoritesViewModel: FavoritesViewModel by viewModels()
-    lateinit var favoritesListView: RecyclerView
+    private lateinit var favoritesListView: RecyclerView
     private lateinit var nearbyAdapter: NearbyAdapter
 
     private var _binding: FavoritesFragmentBinding? = null
@@ -41,7 +40,6 @@ class FavoritesFragment : Fragment() {
         favoritesListView.layoutManager =
             LinearLayoutManager(requireContext(), LinearLayoutManager.VERTICAL, false)
         nearbyAdapter = NearbyAdapter ({
-            MainActivityViewModel.mutableStatusMessage.value = "LOADING"
             val action = FavoritesFragmentDirections
                 .actionFavoritesFragmentToByIdFragment(it)
             view.findNavController().navigate(action)

--- a/app/src/main/java/com/taitsmith/busboy/ui/MainActivity.kt
+++ b/app/src/main/java/com/taitsmith/busboy/ui/MainActivity.kt
@@ -10,7 +10,6 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.core.app.ActivityCompat
 import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
@@ -21,7 +20,6 @@ import com.google.android.material.bottomnavigation.BottomNavigationView
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.snackbar.Snackbar
 import com.taitsmith.busboy.R
-import com.taitsmith.busboy.data.Prediction
 import com.taitsmith.busboy.databinding.ActivityMainBinding
 import com.taitsmith.busboy.viewmodels.MainActivityViewModel
 import com.taitsmith.busboy.viewmodels.NearbyViewModel
@@ -32,9 +30,12 @@ import kotlinx.coroutines.launch
 @AndroidEntryPoint
 class MainActivity : AppCompatActivity() {
 
+    private val PERMISSION_REQUEST_FINE_LOCATION = 6
+
     private lateinit var bottomNavigationView: BottomNavigationView
     private lateinit var navController: NavController
     private lateinit var navHostFragment: NavHostFragment
+    private lateinit var mainActivityViewModel: MainActivityViewModel
 
     private var nearbyStatusUpdateTv: TextView? = null
     private var _binding: ActivityMainBinding? = null
@@ -162,14 +163,5 @@ class MainActivity : AppCompatActivity() {
                 NearbyViewModel.locationPermGranted.value = true
             }
         }
-    }
-
-    companion object {
-        private const val PERMISSION_REQUEST_FINE_LOCATION = 6
-
-        var mainActivityViewModel: MainActivityViewModel? = null
-        var mutableNearbyStatusUpdater: MutableLiveData<String> = MutableLiveData()
-
-        lateinit var prediction: Prediction
     }
 }

--- a/app/src/main/java/com/taitsmith/busboy/ui/MainActivity.kt
+++ b/app/src/main/java/com/taitsmith/busboy/ui/MainActivity.kt
@@ -90,6 +90,7 @@ class MainActivity : AppCompatActivity() {
             "DIRECTION_FAILURE"     -> showSnackbar(R.string.snackbar_direction_failure)
             "NO_WAYPOINTS"          -> showSnackbar(R.string.snackbar_no_waypoints)
             "NO_SERVICE_SCHEDULED"  -> showSnackbar(R.string.snackbar_no_service_scheduled)
+            "UNKNOWN"                -> showSnackbar(R.string.snackbar_unknown_error)
         }
     }
 

--- a/app/src/main/java/com/taitsmith/busboy/ui/MapsFragment.kt
+++ b/app/src/main/java/com/taitsmith/busboy/ui/MapsFragment.kt
@@ -27,11 +27,11 @@ import com.google.android.material.snackbar.Snackbar
 import com.taitsmith.busboy.R
 import com.taitsmith.busboy.data.Bus
 import com.taitsmith.busboy.viewmodels.ByIdViewModel
-import com.taitsmith.busboy.viewmodels.MainActivityViewModel
 import com.taitsmith.busboy.viewmodels.NearbyViewModel
 
-class MapsFragment : Fragment(), GoogleMap.OnMarkerDragListener, GoogleMap.OnMarkerClickListener,
+class MapsFragment: Fragment(), GoogleMap.OnMarkerDragListener, GoogleMap.OnMarkerClickListener,
     OnMapsSdkInitializedCallback {
+
     private val args: MapsFragmentArgs by navArgs()
     private val byIdViewModel: ByIdViewModel by activityViewModels()
     private val nearbyViewModel: NearbyViewModel by activityViewModels()
@@ -83,8 +83,6 @@ class MapsFragment : Fragment(), GoogleMap.OnMarkerDragListener, GoogleMap.OnMar
         googleMap.setOnMarkerClickListener(this)
         googleMap.setOnMarkerDragListener(this)
 
-        MainActivityViewModel.mutableStatusMessage.value = "LOADED"
-
         view?.rootView?.let {
             Snackbar.make(it, R.string.snackbar_map_long_press_drag, Snackbar.LENGTH_LONG)
                 .show()
@@ -125,8 +123,6 @@ class MapsFragment : Fragment(), GoogleMap.OnMarkerDragListener, GoogleMap.OnMar
             googleMap.moveCamera(CameraUpdateFactory.newLatLngZoom(
                 LatLng(bus.latitude!!, bus.longitude!!), 15F))
         }
-
-        MainActivityViewModel.mutableStatusMessage.value = "LOADED"
     }
 
     override fun onCreateView(

--- a/app/src/main/java/com/taitsmith/busboy/ui/NearbyFragment.kt
+++ b/app/src/main/java/com/taitsmith/busboy/ui/NearbyFragment.kt
@@ -10,7 +10,6 @@ import android.widget.ArrayAdapter
 import android.widget.Button
 import android.widget.EditText
 import android.widget.Spinner
-import androidx.core.content.ContentProviderCompat.requireContext
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.Lifecycle
@@ -24,19 +23,15 @@ import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.taitsmith.busboy.R
 import com.taitsmith.busboy.data.Stop
 import com.taitsmith.busboy.databinding.FragmentNearbyBinding
-import com.taitsmith.busboy.di.LocationRepository
 import com.taitsmith.busboy.utils.NearbyAdapter
 import com.taitsmith.busboy.viewmodels.NearbyViewModel
-import com.taitsmith.busboy.viewmodels.NearbyViewModel.NearbyStopsState
 import com.taitsmith.busboy.viewmodels.NearbyViewModel.ListLoadingState
+import com.taitsmith.busboy.viewmodels.NearbyViewModel.NearbyStopsState
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
-import javax.inject.Inject
 
 @AndroidEntryPoint
 class NearbyFragment : Fragment(), AdapterView.OnItemSelectedListener, DialogInterface.OnClickListener {
-    @Inject
-    lateinit var locationRepository: LocationRepository
 
     private lateinit var nearbyStopListView: RecyclerView
     private lateinit var nearbySearchButton: Button
@@ -144,7 +139,6 @@ class NearbyFragment : Fragment(), AdapterView.OnItemSelectedListener, DialogInt
         buslineSpinner.onItemSelectedListener = null
         buslineSpinner.adapter = null
         _binding = null
-        locationRepository.stopUpdates()
     }
 
     private fun setObservers() {

--- a/app/src/main/java/com/taitsmith/busboy/ui/NearbyFragment.kt
+++ b/app/src/main/java/com/taitsmith/busboy/ui/NearbyFragment.kt
@@ -71,7 +71,7 @@ class NearbyFragment : Fragment(), AdapterView.OnItemSelectedListener, DialogInt
                         is NearbyStopsState.Loading -> {
                             when (it.loadState) {
                                 ListLoadingState.START -> {}
-                                ListLoadingState.PARTIAL -> nearbyViewModel.getNearbyStopsWithLines()
+                                ListLoadingState.PARTIAL -> nearbyViewModel.getNearbyStopsWithLines(it.stopList)
                                 ListLoadingState.COMPLETE -> nearbyAdapter.submitList(it.stopList)
                             }
                         }

--- a/app/src/main/java/com/taitsmith/busboy/utils/Constants.kt
+++ b/app/src/main/java/com/taitsmith/busboy/utils/Constants.kt
@@ -1,0 +1,4 @@
+package com.taitsmith.busboy.utils
+
+class Constants {
+}

--- a/app/src/main/java/com/taitsmith/busboy/utils/NearbyAdapter.kt
+++ b/app/src/main/java/com/taitsmith/busboy/utils/NearbyAdapter.kt
@@ -16,7 +16,7 @@ class NearbyAdapter(
     companion object {
         private val DiffCallback = object: DiffUtil.ItemCallback<Stop>() {
             override fun areItemsTheSame(oldItem: Stop, newItem: Stop): Boolean {
-                return oldItem.id == newItem.id
+                return oldItem.stopId == newItem.stopId
             }
 
             override fun areContentsTheSame(oldItem: Stop, newItem: Stop): Boolean {

--- a/app/src/main/java/com/taitsmith/busboy/utils/NearbyAdapter.kt
+++ b/app/src/main/java/com/taitsmith/busboy/utils/NearbyAdapter.kt
@@ -3,8 +3,8 @@ package com.taitsmith.busboy.utils
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.recyclerview.widget.DiffUtil
-import androidx.recyclerview.widget.RecyclerView
 import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
 import com.taitsmith.busboy.data.Stop
 import com.taitsmith.busboy.databinding.ListItemNearbyBinding
 

--- a/app/src/main/java/com/taitsmith/busboy/utils/StatusInterface.kt
+++ b/app/src/main/java/com/taitsmith/busboy/utils/StatusInterface.kt
@@ -1,0 +1,6 @@
+package com.taitsmith.busboy.utils
+
+interface StatusInterface {
+    fun updateStatus(msg: String)
+    fun isLoading(loading: Boolean)
+}

--- a/app/src/main/java/com/taitsmith/busboy/utils/StatusRepo.kt
+++ b/app/src/main/java/com/taitsmith/busboy/utils/StatusRepo.kt
@@ -1,0 +1,24 @@
+package com.taitsmith.busboy.utils
+
+import com.taitsmith.busboy.viewmodels.MainActivityViewModel.LoadingState
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.update
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class StatusRepo @Inject constructor(): StatusInterface {
+
+    var state: MutableStateFlow<LoadingState> = MutableStateFlow(LoadingState.Success)
+
+    override fun updateStatus(msg: String) {
+        state.update {
+            LoadingState.StatusUpdate(msg)
+        }
+    }
+
+    override fun isLoading(loading: Boolean) {
+        if (loading) state.update { LoadingState.Loading }
+        else state.update { LoadingState.Success }
+    }
+}

--- a/app/src/main/java/com/taitsmith/busboy/viewmodels/ByIdViewModel.kt
+++ b/app/src/main/java/com/taitsmith/busboy/viewmodels/ByIdViewModel.kt
@@ -96,17 +96,17 @@ class ByIdViewModel @Inject constructor(
         }
     }
 
-    fun addStopToFavorites() {
-        if (_stop.value == null) statusRepo.updateStatus("BAD_INPUT")
-        else {
-            viewModelScope.launch(Dispatchers.IO) {
-                stop.value?.linesServed = //oh lawd, we'll simplify this
-                    apiRepository.getLinesServedByStop(listOf(stop.value!!))[0].linesServed
-                databaseRepository.addStops(stop.value!!)
-                statusRepo.updateStatus("FAVORITE_ADDED")
-            }
-        }
-    }
+//    fun addStopToFavorites() {
+//        if (_stop.value == null) statusRepo.updateStatus("BAD_INPUT")
+//        else {
+//            viewModelScope.launch(Dispatchers.IO) {
+//                stop.value?.linesServed = //oh lawd, we'll simplify this
+//                    apiRepository.getLinesServedByStop(listOf(stop.value!!))[0].linesServed
+//                databaseRepository.addStops(stop.value!!)
+//                statusRepo.updateStatus("FAVORITE_ADDED")
+//            }
+//        }
+//    }
 
     fun getWaypoints(routeName: String) {
         viewModelScope.launch(Dispatchers.IO) {

--- a/app/src/main/java/com/taitsmith/busboy/viewmodels/ByIdViewModel.kt
+++ b/app/src/main/java/com/taitsmith/busboy/viewmodels/ByIdViewModel.kt
@@ -61,6 +61,12 @@ class ByIdViewModel @Inject constructor(
                     _predictionFlow.value = PredictionState.Error(exception)
                 }
                 .collect { predictions ->
+                    _stop.postValue(
+                        Stop(
+                            stopId = id,
+                            name = predictions[0].stpnm
+                        )
+                    )
                     _predictionFlow.value = PredictionState.Success(predictions)
                     getAlerts()
                     statusRepository.isLoading(false)
@@ -99,17 +105,15 @@ class ByIdViewModel @Inject constructor(
         }
     }
 
-//    fun addStopToFavorites() {
-//        if (_stop.value == null) statusRepo.updateStatus("BAD_INPUT")
-//        else {
-//            viewModelScope.launch(Dispatchers.IO) {
-//                stop.value?.linesServed = //oh lawd, we'll simplify this
-//                    apiRepository.getLinesServedByStop(listOf(stop.value!!))[0].linesServed
-//                databaseRepository.addStops(stop.value!!)
-//                statusRepo.updateStatus("FAVORITE_ADDED")
-//            }
-//        }
-//    }
+    fun addStopToFavorites() {
+        if (_stop.value == null) statusRepository.updateStatus("BAD_INPUT")
+        else {
+            viewModelScope.launch(Dispatchers.IO) {
+                databaseRepository.addStops(stop.value!!)
+                statusRepository.updateStatus("FAVORITE_ADDED")
+            }
+        }
+    }
 
     fun getWaypoints(routeName: String) {
         viewModelScope.launch(Dispatchers.IO) {

--- a/app/src/main/java/com/taitsmith/busboy/viewmodels/ByIdViewModel.kt
+++ b/app/src/main/java/com/taitsmith/busboy/viewmodels/ByIdViewModel.kt
@@ -5,7 +5,6 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.google.android.gms.maps.model.LatLng
-import com.taitsmith.busboy.api.AcTransitRemoteDataSource
 import com.taitsmith.busboy.api.ApiRepository
 import com.taitsmith.busboy.api.ServiceAlertResponse
 import com.taitsmith.busboy.data.Bus
@@ -95,13 +94,13 @@ class ByIdViewModel @Inject constructor(
         _bus.value = BusState.Loading
         viewModelScope.launch {
             val b = apiRepository.vehicleInfo(vehicleId)
-                b.catch { exception ->
-                    _bus.value = BusState.Error(exception)
-                }
-                .collect {
-                    if (bus.value == BusState.Loading) _bus.value = BusState.Initial(it)
-                    else _bus.value = BusState.Updated(it)
+            b.catch { exception ->
+                _bus.value = BusState.Error(exception)
             }
+            .collect {
+                if (bus.value == BusState.Loading) _bus.value = BusState.Initial(it)
+                else _bus.value = BusState.Updated(it)
+        }
         }
     }
 

--- a/app/src/main/java/com/taitsmith/busboy/viewmodels/ByIdViewModel.kt
+++ b/app/src/main/java/com/taitsmith/busboy/viewmodels/ByIdViewModel.kt
@@ -56,13 +56,13 @@ class ByIdViewModel @Inject constructor(
             _stopId.postValue(id)
             apiRepository.stopPredictions
                 .catch { exception ->
-                    _predictionFlow.value = PredictionState.Error(exception)
                     when(exception.message) {
-                    "no_data"       -> MainActivityViewModel.mutableErrorMessage.postValue("404")
-                    "no_service"    -> MainActivityViewModel.mutableErrorMessage.postValue("NO_SERVICE_SCHEDULED")
-                    "empty_list"    -> MainActivityViewModel.mutableErrorMessage.postValue("NULL_PRED_RESPONSE")
-                    "timeout"       -> MainActivityViewModel.mutableErrorMessage.postValue("CALL_FAILURE")
+                        "no_data"       -> MainActivityViewModel.mutableErrorMessage.postValue("404")
+                        "no_service"    -> MainActivityViewModel.mutableErrorMessage.postValue("NO_SERVICE_SCHEDULED")
+                        "empty_list"    -> MainActivityViewModel.mutableErrorMessage.postValue("NULL_PRED_RESPONSE")
+                        "timeout"       -> MainActivityViewModel.mutableErrorMessage.postValue("CALL_FAILURE")
                     }
+                    _predictionFlow.value = PredictionState.Error(exception)
                 }
                 .collect { preds ->
                 _predictionFlow.value = PredictionState.Success(preds)

--- a/app/src/main/java/com/taitsmith/busboy/viewmodels/FavoritesViewModel.kt
+++ b/app/src/main/java/com/taitsmith/busboy/viewmodels/FavoritesViewModel.kt
@@ -5,7 +5,6 @@ import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import com.taitsmith.busboy.data.Stop
 import com.taitsmith.busboy.di.DatabaseRepository
-import com.taitsmith.busboy.viewmodels.MainActivityViewModel.Companion.mutableStatusMessage
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
@@ -27,7 +26,7 @@ class FavoritesViewModel @Inject constructor(application: Application,
         viewModelScope.launch(Dispatchers.IO) {
             databaseRepository.deleteStop(stop)
         }
-        mutableStatusMessage.value = "STOP_DELETED"
+//        mutableStatusMessage.value = "STOP_DELETED"
     }
 
     init {

--- a/app/src/main/java/com/taitsmith/busboy/viewmodels/MainActivityViewModel.kt
+++ b/app/src/main/java/com/taitsmith/busboy/viewmodels/MainActivityViewModel.kt
@@ -2,7 +2,7 @@ package com.taitsmith.busboy.viewmodels
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.taitsmith.busboy.utils.StatusRepo
+import com.taitsmith.busboy.di.StatusRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -11,7 +11,7 @@ import javax.inject.Inject
 
 @HiltViewModel
 class MainActivityViewModel @Inject constructor(
-    private val statusRepo: StatusRepo
+    private val statusRepository: StatusRepository
 )  : ViewModel() {
 
     private val _uiState = MutableStateFlow<LoadingState>(LoadingState.Success)
@@ -19,7 +19,7 @@ class MainActivityViewModel @Inject constructor(
 
     init {
         viewModelScope.launch {
-            statusRepo.state.collect {
+            statusRepository.state.collect {
                 _uiState.value = it
             }
         }

--- a/app/src/main/java/com/taitsmith/busboy/viewmodels/MainActivityViewModel.kt
+++ b/app/src/main/java/com/taitsmith/busboy/viewmodels/MainActivityViewModel.kt
@@ -1,22 +1,33 @@
 package com.taitsmith.busboy.viewmodels
 
-import android.app.Application
-import androidx.lifecycle.AndroidViewModel
-import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.taitsmith.busboy.utils.StatusRepo
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
 class MainActivityViewModel @Inject constructor(
-    application: Application) : AndroidViewModel(application) {
+    private val statusRepo: StatusRepo
+)  : ViewModel() {
 
-    companion object {
-        lateinit var mutableStatusMessage: MutableLiveData<String>
-        lateinit var mutableErrorMessage: MutableLiveData<String>
-    }
+    private val _uiState = MutableStateFlow<LoadingState>(LoadingState.Success)
+    val uiState: StateFlow<LoadingState> = _uiState
 
     init {
-        mutableStatusMessage = MutableLiveData()
-        mutableErrorMessage = MutableLiveData()
+        viewModelScope.launch {
+            statusRepo.state.collect {
+                _uiState.value = it
+            }
+        }
+    }
+
+    sealed class LoadingState {
+        data object Loading : LoadingState()
+        data object Success : LoadingState()
+        data class StatusUpdate(val msg: String) : LoadingState()
     }
 }

--- a/app/src/main/java/com/taitsmith/busboy/viewmodels/NearbyViewModel.kt
+++ b/app/src/main/java/com/taitsmith/busboy/viewmodels/NearbyViewModel.kt
@@ -14,7 +14,8 @@ import com.google.android.gms.maps.model.LatLng
 import com.taitsmith.busboy.api.AcTransitRemoteDataSource
 import com.taitsmith.busboy.api.ApiRepository
 import com.taitsmith.busboy.data.Stop
-import com.taitsmith.busboy.viewmodels.MainActivityViewModel.Companion.mutableErrorMessage
+import com.taitsmith.busboy.di.LocationRepository
+import com.taitsmith.busboy.di.StatusRepo
 import dagger.hilt.android.lifecycle.HiltViewModel
 import im.delight.android.location.SimpleLocation
 import kotlinx.coroutines.Dispatchers
@@ -28,10 +29,10 @@ import javax.inject.Inject
 class NearbyViewModel @Inject constructor(
     private val application: Application,
     private val apiRepository: ApiRepository,
+    private val statusRepo: StatusRepo,
+    private val locationRepository: LocationRepository
                                           ) : AndroidViewModel(application) {
 
-    private val _permGrantedAndEnabled = MutableLiveData<Boolean>()
-    var permGrantedAndEnabled: LiveData<Boolean> = _permGrantedAndEnabled
 
     private val _isUpdated = MutableLiveData<Boolean>()
     val isUpdated: LiveData<Boolean> = _isUpdated
@@ -42,6 +43,10 @@ class NearbyViewModel @Inject constructor(
 
     private val _nearbyStopsFlow = MutableStateFlow<NearbyStopsState>(NearbyStopsState.Loading(ListLoadingState.START, emptyList()))
     val nearbyStopsState: StateFlow<NearbyStopsState> = _nearbyStopsFlow
+
+    //only enable the search button if there's a location or users has selected 'choose on map'
+    private val _enableSearchButton = MutableStateFlow(false)
+    val enableSearchButton: StateFlow<Boolean> = _enableSearchButton
 
     private lateinit var stopList: MutableList<Stop>
 
@@ -67,10 +72,10 @@ class NearbyViewModel @Inject constructor(
     //gets a list of all stops within [distance] feet of [lat]/[lon] that serve line [rt]
     //or all stops if unspecified
     fun getNearbyStops() {
-        MainActivityViewModel.mutableStatusMessage.value = "LOADING"
+        statusRepo.isLoading(true)
         if (rt == null) rt = ""
         if (currentLocation.latitude == 0.0) {
-            mutableErrorMessage.value = "NULL_LOCATION"
+            statusRepo.updateStatus("NULL_LOCATION")
         } else {
             AcTransitRemoteDataSource.setNearbyInfo(
                 currentLocation.latitude,
@@ -81,8 +86,8 @@ class NearbyViewModel @Inject constructor(
                 apiRepository.nearbyStops
                     .catch {
                         it.printStackTrace()
-                        if (it.message == "timeout") mutableErrorMessage.postValue("CALL_FAILURE")
-                        else mutableErrorMessage.postValue("404")
+                        if (it.message.equals("timeout")) statusRepo.updateStatus("CALL_FAILURE")
+                        else statusRepo.updateStatus("404")
                     }
                     .collect{
                         _nearbyStopsFlow.value = NearbyStopsState.Loading(ListLoadingState.PARTIAL, it)
@@ -93,7 +98,9 @@ class NearbyViewModel @Inject constructor(
     }
 
     //collects edited stops (lines added) and updates the stop in list
+    //hella goofy
     fun getNearbyStopsWithLines() {
+        statusRepo.isLoading(false)
         var i = 0
         viewModelScope.launch {
             apiRepository.nearbyStopsWithLines
@@ -118,14 +125,15 @@ class NearbyViewModel @Inject constructor(
             ) == PackageManager.PERMISSION_GRANTED
         ) {
             return if (loc.hasLocationEnabled()) {
-                _permGrantedAndEnabled.value = true
+                locationRepository.startUpdates()
+                statusRepo.updateStatus("WAITING_ON_LOCATION")
                 true
             } else {
-                mutableErrorMessage.value = "NO_LOC_ENABLED" //granted permissions, but location is disabled.
+                statusRepo.updateStatus("NO_LOC_ENABLED")
                 false
             }
         }
-        mutableErrorMessage.value = "NO_PERMISSION"
+        statusRepo.updateStatus("NO_PERMISSION")
         return false
     }
 
@@ -137,7 +145,7 @@ class NearbyViewModel @Inject constructor(
                 _isUpdated.postValue(false)
             }.onFailure {
                 Log.d("FAILURE: ", it.message.toString())
-                mutableErrorMessage.postValue("DIRECTION_FAILURE")
+                statusRepo.updateStatus("DIRECTION_FAILURE")
             }
         }
     }
@@ -148,17 +156,28 @@ class NearbyViewModel @Inject constructor(
 
     fun setLocation(location: Location) {
         currentLocation = location
+        _enableSearchButton.value = true
     }
 
     fun setIsUsingLocation(usingLocation: Boolean) {
         //if user has selected the option to use the device location, make sure we have
         //permission and location setting is enabled
-        if (usingLocation && checkLocationPerm()) _permGrantedAndEnabled.value = true
+        if (usingLocation && checkLocationPerm()) _enableSearchButton.value = true
 
         //disable the 'choose location method' dialog for now
         shouldShowDialog = false
 
         isUsingLocation = usingLocation
+    }
+
+    fun updateStatus(s: String) = statusRepo.updateStatus(s)
+
+    private fun listenForLocation() {
+        viewModelScope.launch {
+            locationRepository.lastLocation.collect { location ->
+                if (location != null) setLocation(location)
+            }
+        }
     }
 
 
@@ -172,11 +191,12 @@ class NearbyViewModel @Inject constructor(
     init {
         currentLocation = Location(null)
         distance = 1000
+
+        listenForLocation()
     }
 
     sealed class NearbyStopsState {
         data class Success(val stops: Stop): NearbyStopsState()
-        data class Error(val exception: Throwable): NearbyStopsState()
         data class Loading(val loadState: ListLoadingState, var stopList: List<Stop>): NearbyStopsState()
     }
 

--- a/app/src/main/java/com/taitsmith/busboy/viewmodels/NearbyViewModel.kt
+++ b/app/src/main/java/com/taitsmith/busboy/viewmodels/NearbyViewModel.kt
@@ -11,7 +11,6 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.viewModelScope
 import com.google.android.gms.maps.model.LatLng
-import com.taitsmith.busboy.api.AcTransitRemoteDataSource
 import com.taitsmith.busboy.api.ApiRepository
 import com.taitsmith.busboy.data.Stop
 import com.taitsmith.busboy.di.LocationRepository

--- a/app/src/main/res/layout/fragment_nearby.xml
+++ b/app/src/main/res/layout/fragment_nearby.xml
@@ -34,6 +34,7 @@
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:text="@string/search_button_text"
+            android:enabled="false"
             app:layout_constraintBottom_toTopOf="@+id/nearbyHorizGuideline"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="@+id/nearbyVertGuideline50"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -70,6 +70,7 @@
     <string name="snackbar_direction_failure">Looks like there was an issue getting directions</string>
     <string name="snackbar_no_waypoints">Looks like an error fetching route data</string>
     <string name="snackbar_no_service_scheduled">Looks like there\'s no service scheduled for this stop today</string>
+    <string name="snackbar_unknown_error">Looks like something went wrong…</string>
 
     <!-- snackbars (informational) -->
     <string name="snackbar_favorite_added">Stop added to favorites</string>

--- a/app/src/test/java/com/taitsmith/busboy/FakeRemoteDataSource.kt
+++ b/app/src/test/java/com/taitsmith/busboy/FakeRemoteDataSource.kt
@@ -1,0 +1,4 @@
+package com.taitsmith.busboy
+
+class FakeRemoteDataSource {
+}


### PR DESCRIPTION
version 1.2.2

- changes a bunch of the live data stuff to use flows / state flow:
  - nearby search results are displayed as as they come in, instead of waiting for the entire list to be populated
  - nearby stops with no scheduled service won't be displayed (eg stops that only serve 6XX lines won't be displayed on weekends)
  - status / error messages now handled through mutable state flow
  - predictions screen and bus location will now automatically update if left open
  - location updates should now be handled better
- does a lot of cleanup / refactoring
- probably some other things too